### PR TITLE
Update documentation: Phase 2 tools and composition workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,15 @@ See [docs/QUICKSTART.md](docs/QUICKSTART.md) for a full walkthrough.
 | `pptx_get_slide_content` | Extract structured content from a slide (shapes, text, tables) |
 | `pptx_get_slide_xml` | Get the raw XML for a slide (power users) |
 | `pptx_add_slide` | Add a new slide using a named layout |
-| `pptx_update_text` | Update text in a placeholder on a slide |
-| `pptx_update_slide_data` | Update a named or indexed shape while preserving formatting |
+| `pptx_update_text` | Update text in a placeholder on a slide by index |
+| `pptx_update_slide_data` | Update a named or indexed shape while preserving formatting — preferred for data-driven updates |
 | `pptx_insert_image` | Embed an image (PNG, JPG, GIF) on a slide |
 | `pptx_extract_talking_points` | Extract the highest-signal talking points from each slide |
 | `pptx_export_markdown` | Export a full presentation to a structured markdown file |
+
+**When to use `pptx_update_slide_data` vs `pptx_update_text`:** Use `pptx_update_slide_data` when shapes have descriptive names (check `pptx_get_slide_content`) — it targets shapes by name and preserves their existing formatting. Use `pptx_update_text` for anonymous placeholders identified only by index.
+
+**Limitations:** pptx-mcp updates text content and inserts images. It does not create charts, modify slide master/theme styles, or reorder slides. Complex layout changes should be done in PowerPoint directly.
 
 → Full parameter docs and examples: [docs/TOOL_REFERENCE.md](docs/TOOL_REFERENCE.md)
 

--- a/docs/CLIENT_SETUP.md
+++ b/docs/CLIENT_SETUP.md
@@ -13,6 +13,8 @@ This guide shows how to configure different MCP clients to use **pptx-mcp**, a .
   - [Codeium / Windsurf](#codeium--windsurf)
 - [Command-Line / Custom Clients](#command-line--custom-clients)
 - [Local LLMs](#local-llms)
+- [Configuring Multiple MCPs](#configuring-multiple-mcps)
+- [Composition Tips](#composition-tips)
 - [Troubleshooting](#troubleshooting)
 
 ---
@@ -335,6 +337,84 @@ env:     (no special environment variables required)
 
 ---
 
+## Configuring Multiple MCPs
+
+pptx-mcp is designed to be composed with other MCP servers. A common pattern is to pair it with a data source MCP so an AI agent can fetch live data and update slides in a single prompt — no glue code required.
+
+### Claude Desktop — multiple servers
+
+Add each server as a separate entry under `mcpServers`. Claude Desktop loads all configured servers at startup and makes all their tools available to the agent simultaneously:
+
+```json
+{
+  "mcpServers": {
+    "pptx-mcp": {
+      "command": "pptx-mcp"
+    },
+    "mock-data-mcp": {
+      "command": "dotnet",
+      "args": [
+        "run",
+        "--project",
+        "/absolute/path/to/pptx-mcp/examples/mock-data-mcp",
+        "--configuration",
+        "Release"
+      ]
+    }
+  }
+}
+```
+
+### VS Code (Copilot) — multiple servers
+
+Add each server to `.vscode/mcp.json`:
+
+```json
+{
+  "servers": {
+    "pptx-mcp": {
+      "type": "stdio",
+      "command": "pptx-mcp"
+    },
+    "mock-data-mcp": {
+      "type": "stdio",
+      "command": "dotnet",
+      "args": [
+        "run",
+        "--project",
+        "${workspaceFolder}/examples/mock-data-mcp",
+        "--configuration",
+        "Release"
+      ]
+    }
+  }
+}
+```
+
+The agent sees tools from all configured servers and selects the right one based on each tool's description.
+
+See [docs/MULTI_SOURCE_COMPOSITION.md](MULTI_SOURCE_COMPOSITION.md) for full configuration examples and step-by-step walkthroughs, including the built-in [mock-data-mcp](../examples/mock-data-mcp/) server you can run locally without any API keys.
+
+---
+
+## Composition Tips
+
+These guidelines apply when pptx-mcp is used alongside other MCP servers:
+
+- **Inspect before writing.** Call `pptx_get_slide_content` on the target slide before making updates. This gives the agent the exact shape names and indices needed to target the right element, and avoids overwriting the wrong content.
+
+- **Prefer `pptx_update_slide_data` for named shapes.** When a shape has a descriptive name (visible as `Name` in `pptx_get_slide_content`), use `pptx_update_slide_data` with `shapeName`. It preserves the shape's existing formatting and is more resilient to deck layout changes than index-based addressing.
+
+- **Anchor updates to slide titles.** In agent prompts, say "update the slide titled 'KPI Summary'" rather than "update slide 3". Slide positions can shift as decks evolve; titles are stable.
+
+- **Be explicit about which server to use for each step.** Telling the agent "use `get_weekly_metrics` from mock-data-mcp, then update the deck using pptx-mcp" reduces ambiguity and prevents the agent from guessing which tool to invoke.
+
+- **Specify the update scope.** Clarify which placeholders to change and which to leave alone — for example, "update the body placeholder but keep the title unchanged". This prevents unintended overwrites.
+
+- **Use absolute paths.** Always pass absolute file paths to pptx-mcp tools. Relative paths resolve against the server's working directory, which may not be what you expect.
+
+---
+
 ## Troubleshooting
 
 ### `pptx-mcp` command not found
@@ -413,8 +493,10 @@ Once connected, the following MCP tools are available:
 | `pptx_get_slide_content` | Get structured content (shapes, text, positions) for a slide |
 | `pptx_get_slide_xml` | Get the raw XML of a slide (advanced) |
 | `pptx_add_slide` | Add a new slide with a specified layout |
-| `pptx_update_text` | Update the text of a placeholder on a slide |
+| `pptx_update_text` | Update the text of a placeholder on a slide by index |
 | `pptx_update_slide_data` | Update a named or indexed slide shape while preserving formatting |
 | `pptx_insert_image` | Insert an image onto a slide |
+| `pptx_extract_talking_points` | Extract ranked talking points from each slide |
+| `pptx_export_markdown` | Export a full presentation to a structured markdown file |
 
 A good first test after connecting is to call `pptx_list_slides` with a known `.pptx` file path. A successful response confirms the server is connected and operational.

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -358,10 +358,10 @@ I have a weekly board presentation at /presentations/weekly-board.pptx.
    { "name": "pptx_get_slide_content", "arguments": { "filePath": "/presentations/weekly-board.pptx", "slideIndex": 1 } }
    ```
 
-5. **`pptx_update_text`** (pptx-mcp, repeated) — Write each new KPI value to its placeholder.
+5. **`pptx_update_slide_data`** (pptx-mcp, repeated) — Write each new KPI value to its named shape, preserving formatting.
 
    ```json
-   { "name": "pptx_update_text", "arguments": { "filePath": "/presentations/weekly-board.pptx", "slideIndex": 1, "placeholderIndex": 1, "text": "$19.6M ARR (+3.3%)" } }
+   { "name": "pptx_update_slide_data", "arguments": { "filePath": "/presentations/weekly-board.pptx", "slideNumber": 2, "shapeName": "ARR", "newText": "$19.6M ARR (+3.3%)" } }
    ```
 
 ### Example Output

--- a/docs/MULTI_SOURCE_COMPOSITION.md
+++ b/docs/MULTI_SOURCE_COMPOSITION.md
@@ -33,9 +33,11 @@ Multi-source composition is the practice of configuring an AI agent with two or 
         │ get_weekly_    │           │ pptx_get_slide_ │
         │ metrics        │           │   content       │
         │ get_team_      │           │ pptx_update_    │
-        │ updates        │           │   text          │
-        │ get_latest_    │           │ pptx_add_slide  │
-        │ blog_posts     │           │ pptx_insert_    │
+        │ updates        │           │   slide_data    │
+        │ get_latest_    │           │ pptx_update_    │
+        │ blog_posts     │           │   text          │
+        │                │           │ pptx_add_slide  │
+        │                │           │ pptx_insert_    │
         └────────────────┘           │   image         │
                                      └─────────────────┘
 ```
@@ -282,19 +284,19 @@ Response (excerpt):
 }
 ```
 
-**Step 5 — Update KPI placeholders with fresh data**
+**Step 5 — Update KPI shapes by name with fresh data**
 
-The agent makes one `pptx_update_text` call per placeholder:
+Because the KPI shapes have descriptive names (`ARR`, `MRR`, etc.), the agent can target them directly without relying on placeholder indices:
 
 ```json
 {
   "server": "pptx-mcp",
-  "name": "pptx_update_text",
+  "name": "pptx_update_slide_data",
   "arguments": {
     "filePath": "/presentations/weekly-board.pptx",
-    "slideIndex": 1,
-    "placeholderIndex": 1,
-    "text": "$19.6M ARR (+3.3%)"
+    "slideNumber": 2,
+    "shapeName": "ARR",
+    "newText": "$19.6M ARR (+3.3%)"
   }
 }
 ```
@@ -302,17 +304,19 @@ The agent makes one `pptx_update_text` call per placeholder:
 ```json
 {
   "server": "pptx-mcp",
-  "name": "pptx_update_text",
+  "name": "pptx_update_slide_data",
   "arguments": {
     "filePath": "/presentations/weekly-board.pptx",
-    "slideIndex": 1,
-    "placeholderIndex": 2,
-    "text": "$1.63M MRR"
+    "slideNumber": 2,
+    "shapeName": "MRR",
+    "newText": "$1.63M MRR"
   }
 }
 ```
 
 *(… repeated for NRR, New Logos, and Churn)*
+
+`pptx_update_slide_data` preserves the existing font, size, and colour of the target shape. Use `pptx_update_text` when the slide uses anonymous placeholders and you only have an index.
 
 **Step 6 — Update team updates slide**
 
@@ -321,12 +325,12 @@ After inspecting slide 2 with `pptx_get_slide_content`, the agent updates the bo
 ```json
 {
   "server": "pptx-mcp",
-  "name": "pptx_update_text",
+  "name": "pptx_update_slide_data",
   "arguments": {
     "filePath": "/presentations/weekly-board.pptx",
-    "slideIndex": 2,
-    "placeholderIndex": 1,
-    "text": "Engineering: on-track — shipped v3.4.0, latency down 12%\nSales: ahead — $2.1M pipeline, 46% win rate\nSupport: on-track — CSAT 4.6/5.0, 2h first response\nMarketing: on-track — 1,400 blog views, 330 webinar registrations"
+    "slideNumber": 3,
+    "shapeName": "Updates",
+    "newText": "Engineering: on-track — shipped v3.4.0, latency down 12%\nSales: ahead — $2.1M pipeline, 46% win rate\nSupport: on-track — CSAT 4.6/5.0, 2h first response\nMarketing: on-track — 1,400 blog views, 330 webinar registrations"
   }
 }
 ```
@@ -336,12 +340,12 @@ After inspecting slide 2 with `pptx_get_slide_content`, the agent updates the bo
 ```json
 {
   "server": "pptx-mcp",
-  "name": "pptx_update_text",
+  "name": "pptx_update_slide_data",
   "arguments": {
     "filePath": "/presentations/weekly-board.pptx",
-    "slideIndex": 0,
+    "slideNumber": 1,
     "placeholderIndex": 1,
-    "text": "Week of June 9–15, 2025"
+    "newText": "Week of June 9–15, 2025"
   }
 }
 ```
@@ -491,13 +495,19 @@ The agent decides which server to query at each step based on the task. MCP tool
 
 The pptx-mcp side of the workflow stays unchanged.
 
-### Using `pptx_update_text` vs. a future `pptx_update_slide_data`
+### Using `pptx_update_slide_data` vs. `pptx_update_text`
 
-The current examples use `pptx_update_text`, which updates one placeholder at a time. This works but requires:
-1. An inspection call (`pptx_get_slide_content`) to find placeholder indices
-2. One `pptx_update_text` call per value
+**Prefer `pptx_update_slide_data`** when shapes have descriptive names (visible in `pptx_get_slide_content` as the `Name` field). It targets shapes by name rather than by position, which is more robust if the deck layout changes. It also preserves existing font, size, and colour — the formatting stays exactly as designed.
 
-A future `pptx_update_slide_data` tool (Phase 2) will accept a data map and update all matching placeholders in a single call, streamlining the pattern for data-heavy slides.
+**Use `pptx_update_text`** when working with anonymous placeholders identified only by index, or when you do not need to preserve per-run formatting.
+
+Workflow comparison:
+
+| Scenario | Recommended tool |
+|---|---|
+| Named shape (`"ARR"`, `"Title 1"`, etc.) | `pptx_update_slide_data` with `shapeName` |
+| No shape name, index known | `pptx_update_slide_data` with `placeholderIndex` |
+| Bulk plain-text replace, formatting unimportant | `pptx_update_text` |
 
 ### Agent prompt design tips
 

--- a/docs/TOOL_REFERENCE.md
+++ b/docs/TOOL_REFERENCE.md
@@ -252,7 +252,7 @@ Error: File not found: /path/to/presentation.pptx
 
 ---
 
-
+## pptx_get_slide_content
 
 **Description:** Get structured content from a slide: all shapes with their type, position, size, and text. Returns a JSON object with slide dimensions and a shapes array. Prefer this over `pptx_get_slide_xml` when you need to read or reason about slide content.
 
@@ -720,5 +720,56 @@ On failure, `Success` is `false` and `Message` explains what was missing or out 
   "PreviousText": "$4.2M",
   "NewText": "$4.6M",
   "Message": "Updated shape 'ARR Value' on slide 3."
+}
+```
+
+**Request (fallback by index when no shape name is known):**
+```json
+{
+  "name": "pptx_update_slide_data",
+  "arguments": {
+    "filePath": "/presentations/quarterly-review.pptx",
+    "slideNumber": 3,
+    "placeholderIndex": 2,
+    "newText": "$4.6M"
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "Success": true,
+  "SlideNumber": 3,
+  "RequestedShapeName": null,
+  "RequestedPlaceholderIndex": 2,
+  "MatchedBy": "placeholderIndex",
+  "ResolvedShapeName": "ARR Value",
+  "ResolvedShapeIndex": 2,
+  "ResolvedShapeId": 5,
+  "PlaceholderType": "body",
+  "LayoutPlaceholderIndex": null,
+  "PreviousText": "$4.2M",
+  "NewText": "$4.6M",
+  "Message": "Updated shape at index 2 on slide 3."
+}
+```
+
+**Response (shape not found):**
+```json
+{
+  "Success": false,
+  "SlideNumber": 3,
+  "RequestedShapeName": "Revenue Total",
+  "RequestedPlaceholderIndex": null,
+  "MatchedBy": null,
+  "ResolvedShapeName": null,
+  "ResolvedShapeIndex": null,
+  "ResolvedShapeId": null,
+  "PlaceholderType": null,
+  "LayoutPlaceholderIndex": null,
+  "PreviousText": null,
+  "NewText": "$4.6M",
+  "Message": "No shape named 'Revenue Total' found on slide 3, and no placeholderIndex was supplied."
 }
 ```


### PR DESCRIPTION
Closes #16

@copilot updated Phase 2 documentation including tool reference, composition patterns, and CLIENT_SETUP multi-MCP section.