### PR TITLE
refactor: add test categories and extract EMU constants (#68, #70)

### DIFF
--- a/.squad/agents/nate/history.md
+++ b/.squad/agents/nate/history.md
@@ -169,3 +169,20 @@
 - Decision point: Squad can choose to proceed with consolidation as enhancement or focus on Tier 1+2 core quality work
 - Orchestration log written to `.squad/orchestration-log/2026-03-17T0607Z-nate.md`
 - Decisions merged to decisions.md; inbox files deleted
+
+### 2026-03-17T**TBD**: DocumentFormat.OpenXml 3.5.0 Upgrade Research
+
+**Research Scope:** Evaluate DocumentFormat.OpenXml 3.5.0 (released March 13, 2025) vs. current 3.4.1.
+
+**Key Findings:**
+- **3.5.0 additions:** Minor schema release — adds Office2016.Drawing.ChartDrawing.Offset class, Version/FeatureList/FalbackImg attributes on ChartSpace, ExtensionDropMode enum. Purely additive, no breaking changes.
+- **3.4.1 recent wins:** Most significant improvements already in current version — MP4 video support for PPTX, Q3 2025 Office schema updates, ~2.4× faster base64 decoding (~70% less memory), fixed XML serialization, better error reporting for encrypted/missing parts.
+- **Upgrade assessment:** Safe, low-risk. No code changes needed; dependency update only.
+- **Deliverable:** GitHub issue #75 created with upgrade recommendation, impact analysis, testing checklist.
+
+**Impact:** Unblocks potential MP4 video feature work if future requirements arise. No immediate action required—Cheritto can pick up if Squad prioritizes video embedding in Phase 3+.
+
+**File Paths:**
+- `.csproj` reference: `src/PptxMcp/PptxMcp.csproj` line 26
+- Issue: https://github.com/jongalloway/pptx-mcp/issues/75
+- Reference: Open-XML-SDK releases (https://github.com/dotnet/Open-XML-SDK/releases)

--- a/.squad/agents/shiherlis/history.md
+++ b/.squad/agents/shiherlis/history.md
@@ -64,3 +64,29 @@
   - `TableToolsTests.cs` (1 conflict): Same naming changes from #71; PR #65 changed `.First(predicate)` → `Assert.Single`
 - **Resolution strategy:** Keep main's naming conventions (`CreateMinimalPptx`, `Service.`) AND PR's assertion pattern improvements (`Assert.Single` over `FirstOrDefault`/`.Single`/`.First`)
 - **Result:** 377/377 tests passing, CI green, force-pushed with `--force-with-lease`
+### Issue #56 Theory Parameterization Refactor (2026-03-17)
+- **Scope:** Consolidated 14 repetitive file-not-found `[Fact]` tests into 4 `[Theory]` parameterized tests across 3 files
+- **Files modified:**
+  - `tests/PptxMcp.Tests/Tools/PptxToolsTests.cs` — 8 simple "Error:" tests → 1 Theory; 2 replace_image tests → 1 Theory
+  - `tests/PptxMcp.Tests/Tools/TableToolsTests.cs` — 2 table file-not-found tests → 1 Theory (using JsonDocument for type-agnostic assertion)
+  - `tests/PptxMcp.Tests/Tools/ImageReplaceToolTests.cs` — 2 pptx/image-not-found tests → 1 Theory with bool flags for setup variation
+- **Net result:** -55 lines, 260/260 tests passing (unchanged count), adding new tools needs only a new `[InlineData]` row
+- **Patterns used:**
+  - `switch` expression to dispatch tool calls by name string in Theory body
+  - Bool parameters (`pptxExists`, `imageExists`) to vary test setup within a single Theory
+  - `JsonDocument` for type-agnostic Success/Message assertions when result types differ
+- **Key decision:** Left `PptxExportMarkdownToolTests.cs` alone (only 1 file-not-found test — no consolidation value) and kept `BothFilesMissing` test as separate `[Fact]` (tests ordering concern, not just error detection)
+
+### Issue #67 PptxTestBase Extraction (2026-03-17)
+- **Scope:** Extracted `PptxTestBase` abstract base class to eliminate duplicated setup across 16 test files
+- **File created:** `tests/PptxMcp.Tests/PptxTestBase.cs`
+- **Files modified:** 16 test files + `TestPptxHelper.cs` (visibility change for definition types)
+- **Net result:** -239 lines, 260/260 tests passing (unchanged count), PR #71
+- **Base class provides:**
+  - `Service` (PresentationService), `CreateMinimalPptx()`, `CreatePptxWithSlides()`, `TrackTempFile()`, `Dispose()` with ordered cleanup
+- **Key patterns:**
+  - Test definition types (`TestSlideDefinition`, etc.) changed from `internal` to `public` to allow `protected` base class methods
+  - Classes with custom OpenXML fixture creation (ImageReplaceTests, ImageReplaceToolTests) keep their own `CreatePptxWithPicture` and use `CreateTrackedPath()` wrapper for path generation + tracking
+  - `SlideOrganizationTests` uses `CreateNamedSlides(params string[])` wrapper around `CreatePptxWithSlides`
+  - `PptxCompletionHandlerTests` wraps both `CreateMinimalPptx()` and `CreatePptxWithSlides()` in a single `CreateTempPptx(params TestSlideDefinition[])` for backward compatibility
+  - `PptxPromptsTests` has no disposable pattern — correctly excluded from base class

--- a/tests/PptxMcp.Tests/Completions/PptxCompletionHandlerTests.cs
+++ b/tests/PptxMcp.Tests/Completions/PptxCompletionHandlerTests.cs
@@ -3,6 +3,7 @@ using PptxMcp.Completions;
 
 namespace PptxMcp.Tests.Completions;
 
+[Trait("Category", "Integration")]
 public class PptxCompletionHandlerTests : PptxTestBase
 {
     private string CreateTempPptx(params TestSlideDefinition[] slides)

--- a/tests/PptxMcp.Tests/EmuConstants.cs
+++ b/tests/PptxMcp.Tests/EmuConstants.cs
@@ -1,0 +1,74 @@
+namespace PptxMcp.Tests;
+
+/// <summary>
+/// Named constants for English Metric Unit (EMU) values used in OpenXML PowerPoint test fixtures.
+/// </summary>
+/// <remarks>
+/// 1 inch = 914,400 EMU. These constants replace hardcoded magic numbers
+/// to improve readability and make layout intent explicit.
+/// </remarks>
+internal static class Emu
+{
+    /// <summary>0.25 inches (228,600 EMU). Common vertical gap between shapes.</summary>
+    public const long QuarterInch = 228_600;
+
+    /// <summary>0.3 inches (274,320 EMU). Standard title top-margin offset.</summary>
+    public const long Inches0_3 = 274_320;
+
+    /// <summary>0.375 inches (342,900 EMU). Minimum row height for tables.</summary>
+    public const long ThreeEighthsInch = 342_900;
+
+    /// <summary>0.5 inches (457,200 EMU). Half-inch offset used for title X positions.</summary>
+    public const long HalfInch = 457_200;
+
+    /// <summary>0.75 inches (685,800 EMU). Standard title shape height.</summary>
+    public const long ThreeQuartersInch = 685_800;
+
+    /// <summary>1 inch (914,400 EMU). Base conversion factor and common left margin.</summary>
+    public const long OneInch = 914_400;
+
+    /// <summary>1.25 inches (1,143,000 EMU). Body shape height for compact content.</summary>
+    public const long Inches1_25 = 1_143_000;
+
+    /// <summary>1.5 inches (1,371,600 EMU). Standard body content height and Y start.</summary>
+    public const long Inches1_5 = 1_371_600;
+
+    /// <summary>1.75 inches (1,600,200 EMU). Layout body Y position below title.</summary>
+    public const long Inches1_75 = 1_600_200;
+
+    /// <summary>2 inches (1,828,800 EMU). Used for shape widths and picture heights.</summary>
+    public const long Inches2 = 1_828_800;
+
+    /// <summary>2.5 inches (2,286,000 EMU). Source slide picture width.</summary>
+    public const long Inches2_5 = 2_286_000;
+
+    /// <summary>3 inches (2,743,200 EMU). Standard picture/shape dimension.</summary>
+    public const long Inches3 = 2_743_200;
+
+    /// <summary>3.5 inches (3,200,400 EMU). Layout body secondary Y position.</summary>
+    public const long Inches3_5 = 3_200_400;
+
+    /// <summary>4 inches (3,657,600 EMU). Standard picture width and shape offset.</summary>
+    public const long Inches4 = 3_657_600;
+
+    /// <summary>5 inches (4,572,000 EMU). Table X position for dashboard layouts.</summary>
+    public const long Inches5 = 4_572_000;
+
+    /// <summary>5.5 inches (5,029,200 EMU). Right-column shape X position.</summary>
+    public const long Inches5_5 = 5_029_200;
+
+    /// <summary>6 inches (5,486,400 EMU). Source slide picture X position.</summary>
+    public const long Inches6 = 5_486_400;
+
+    /// <summary>7.5 inches (6,858,000 EMU). Standard slide height (4:3 portrait) and notes width.</summary>
+    public const long Inches7_5 = 6_858_000;
+
+    /// <summary>8 inches (7,315,200 EMU). Default body content width.</summary>
+    public const long Inches8 = 7_315_200;
+
+    /// <summary>9 inches (8,229,600 EMU). Full-width title shape span.</summary>
+    public const long Inches9 = 8_229_600;
+
+    /// <summary>10 inches (9,144,000 EMU). Standard slide width (4:3 landscape).</summary>
+    public const long Inches10 = 9_144_000;
+}

--- a/tests/PptxMcp.Tests/Prompts/PptxPromptsTests.cs
+++ b/tests/PptxMcp.Tests/Prompts/PptxPromptsTests.cs
@@ -3,6 +3,7 @@ using PptxMcp.Prompts;
 
 namespace PptxMcp.Tests.Prompts;
 
+[Trait("Category", "Integration")]
 public class PptxPromptsTests
 {
     private readonly PptxPrompts _prompts = new();

--- a/tests/PptxMcp.Tests/Resources/PptxResourcesTests.cs
+++ b/tests/PptxMcp.Tests/Resources/PptxResourcesTests.cs
@@ -4,6 +4,7 @@ using PptxMcp.Resources;
 
 namespace PptxMcp.Tests.Resources;
 
+[Trait("Category", "Integration")]
 public class PptxResourcesTests : PptxTestBase
 {
     private readonly PptxResources _resources;

--- a/tests/PptxMcp.Tests/Services/BatchUpdateTests.cs
+++ b/tests/PptxMcp.Tests/Services/BatchUpdateTests.cs
@@ -5,6 +5,7 @@ using PptxMcp.Models;
 
 namespace PptxMcp.Tests.Services;
 
+[Trait("Category", "Unit")]
 public class BatchUpdateTests : PptxTestBase
 {
 
@@ -155,19 +156,19 @@ public class BatchUpdateTests : PptxTestBase
                                 Level = 1
                             }
                         ],
-                        X = 914400,
-                        Y = 1828800,
-                        Width = 2743200,
-                        Height = 685800
+                        X = Emu.OneInch,
+                        Y = Emu.Inches2,
+                        Width = Emu.Inches3,
+                        Height = Emu.ThreeQuartersInch
                     },
                     new TestTextShapeDefinition
                     {
                         Name = "Gross Margin",
                         Paragraphs = ["62%"],
-                        X = 3657600,
-                        Y = 1828800,
-                        Width = 1828800,
-                        Height = 685800
+                        X = Emu.Inches4,
+                        Y = Emu.Inches2,
+                        Width = Emu.Inches2,
+                        Height = Emu.ThreeQuartersInch
                     },
                     new TestTextShapeDefinition
                     {
@@ -178,10 +179,10 @@ public class BatchUpdateTests : PptxTestBase
                             new TestParagraphDefinition { Text = "Pipeline stable", IsBullet = true },
                             new TestParagraphDefinition { Text = "Upsell motion healthy", IsBullet = true }
                         ],
-                        X = 914400,
-                        Y = 2743200,
-                        Width = 3657600,
-                        Height = 1143000
+                        X = Emu.OneInch,
+                        Y = Emu.Inches3,
+                        Width = Emu.Inches4,
+                        Height = Emu.Inches1_25
                     }
                 ],
                 IncludeImage = true

--- a/tests/PptxMcp.Tests/Services/ImageReplaceTests.cs
+++ b/tests/PptxMcp.Tests/Services/ImageReplaceTests.cs
@@ -7,6 +7,7 @@ using P = DocumentFormat.OpenXml.Presentation;
 
 namespace PptxMcp.Tests.Services;
 
+[Trait("Category", "Unit")]
 public class ImageReplaceTests : PptxTestBase
 {
     private static readonly byte[] PngBytes = Convert.FromBase64String(
@@ -115,8 +116,8 @@ public class ImageReplaceTests : PptxTestBase
 
         presentationPart.Presentation = new Presentation(
             slideIdList,
-            new SlideSize { Cx = 9144000, Cy = 6858000, Type = SlideSizeValues.Screen4x3 },
-            new NotesSize { Cx = 6858000, Cy = 9144000 });
+            new SlideSize { Cx = (int)Emu.Inches10, Cy = (int)Emu.Inches7_5, Type = SlideSizeValues.Screen4x3 },
+            new NotesSize { Cx = (int)Emu.Inches7_5, Cy = (int)Emu.Inches10 });
 
         presentationPart.Presentation.InsertAt(
             new SlideMasterIdList(new SlideMasterId
@@ -319,8 +320,8 @@ public class ImageReplaceTests : PptxTestBase
             var pp = doc.AddPresentationPart();
             pp.Presentation = new Presentation(
                 new SlideIdList(),
-                new SlideSize { Cx = 9144000, Cy = 6858000 },
-                new NotesSize { Cx = 6858000, Cy = 9144000 });
+                new SlideSize { Cx = (int)Emu.Inches10, Cy = (int)Emu.Inches7_5 },
+                new NotesSize { Cx = (int)Emu.Inches7_5, Cy = (int)Emu.Inches10 });
             pp.Presentation.Save();
         }
         var imagePath = CreateTempImage(PngBytes, ".png");
@@ -470,8 +471,8 @@ public class ImageReplaceTests : PptxTestBase
             slidePart.Slide = new Slide(new CommonSlideData(shapeTree), new ColorMapOverride(new A.MasterColorMapping()));
             presentationPart.Presentation = new Presentation(
                 new SlideIdList(new SlideId { Id = 256, RelationshipId = presentationPart.GetIdOfPart(slidePart) }),
-                new SlideSize { Cx = 9144000, Cy = 6858000, Type = SlideSizeValues.Screen4x3 },
-                new NotesSize { Cx = 6858000, Cy = 9144000 });
+                new SlideSize { Cx = (int)Emu.Inches10, Cy = (int)Emu.Inches7_5, Type = SlideSizeValues.Screen4x3 },
+                new NotesSize { Cx = (int)Emu.Inches7_5, Cy = (int)Emu.Inches10 });
             presentationPart.Presentation.InsertAt(
                 new SlideMasterIdList(new SlideMasterId { Id = 2147483648U, RelationshipId = presentationPart.GetIdOfPart(slideMasterPart) }), 0);
             presentationPart.Presentation.Save();
@@ -706,10 +707,10 @@ public class ImageReplaceTests : PptxTestBase
         // Verify shape properties (position/size) are preserved
         var transform = picture.ShapeProperties?.GetFirstChild<A.Transform2D>();
         Assert.NotNull(transform);
-        Assert.Equal(914400, transform!.Offset!.X!.Value);
-        Assert.Equal(914400, transform.Offset!.Y!.Value);
-        Assert.Equal(3657600, transform.Extents!.Cx!.Value);
-        Assert.Equal(2743200, transform.Extents!.Cy!.Value);
+        Assert.Equal(Emu.OneInch, transform!.Offset!.X!.Value);
+        Assert.Equal(Emu.OneInch, transform.Offset!.Y!.Value);
+        Assert.Equal(Emu.Inches4, transform.Extents!.Cx!.Value);
+        Assert.Equal(Emu.Inches3, transform.Extents!.Cy!.Value);
     }
 
     [Fact]

--- a/tests/PptxMcp.Tests/Services/MarkdownExportTests.cs
+++ b/tests/PptxMcp.Tests/Services/MarkdownExportTests.cs
@@ -3,6 +3,7 @@ using System.Text.RegularExpressions;
 
 namespace PptxMcp.Tests.Services;
 
+[Trait("Category", "Unit")]
 public class MarkdownExportTests : PptxTestBase
 {
 

--- a/tests/PptxMcp.Tests/Services/PresentationServiceTests.cs
+++ b/tests/PptxMcp.Tests/Services/PresentationServiceTests.cs
@@ -4,6 +4,7 @@ using A = DocumentFormat.OpenXml.Drawing;
 
 namespace PptxMcp.Tests.Services;
 
+[Trait("Category", "Unit")]
 public class PresentationServiceTests : PptxTestBase
 {
 

--- a/tests/PptxMcp.Tests/Services/SlideOrganizationTests.cs
+++ b/tests/PptxMcp.Tests/Services/SlideOrganizationTests.cs
@@ -1,5 +1,6 @@
 namespace PptxMcp.Tests.Services;
 
+[Trait("Category", "Unit")]
 public class SlideOrganizationTests : PptxTestBase
 {
     private string CreateNamedSlides(params string[] titles) =>

--- a/tests/PptxMcp.Tests/Services/TableOperationTests.cs
+++ b/tests/PptxMcp.Tests/Services/TableOperationTests.cs
@@ -11,6 +11,7 @@ namespace PptxMcp.Tests.Services;
 /// Written proactively for Issue #36 — table insert and update tools.
 /// These tests verify OpenXML structure, PowerPoint compatibility, and behavioral correctness.
 /// </summary>
+[Trait("Category", "Unit")]
 public class TableOperationTests : PptxTestBase
 {
 

--- a/tests/PptxMcp.Tests/Services/TemplateSlideTests.cs
+++ b/tests/PptxMcp.Tests/Services/TemplateSlideTests.cs
@@ -5,6 +5,7 @@ using PptxMcp.Models;
 
 namespace PptxMcp.Tests.Services;
 
+[Trait("Category", "Unit")]
 public class TemplateSlideTests : PptxTestBase
 {
 

--- a/tests/PptxMcp.Tests/Services/UpdateSlideDataTests.cs
+++ b/tests/PptxMcp.Tests/Services/UpdateSlideDataTests.cs
@@ -5,6 +5,7 @@ using A = DocumentFormat.OpenXml.Drawing;
 
 namespace PptxMcp.Tests.Services;
 
+[Trait("Category", "Unit")]
 public class UpdateSlideDataTests : PptxTestBase
 {
 
@@ -170,10 +171,10 @@ public class UpdateSlideDataTests : PptxTestBase
                     {
                         Name = "Revenue Label",
                         Paragraphs = ["Net Revenue"],
-                        X = 914400,
-                        Y = 1371600,
-                        Width = 2743200,
-                        Height = 457200
+                        X = Emu.OneInch,
+                        Y = Emu.Inches1_5,
+                        Width = Emu.Inches3,
+                        Height = Emu.HalfInch
                     },
                     new TestTextShapeDefinition
                     {
@@ -187,19 +188,19 @@ public class UpdateSlideDataTests : PptxTestBase
                                 Level = 1
                             }
                         ],
-                        X = 914400,
-                        Y = 1828800,
-                        Width = 2743200,
-                        Height = 685800
+                        X = Emu.OneInch,
+                        Y = Emu.Inches2,
+                        Width = Emu.Inches3,
+                        Height = Emu.ThreeQuartersInch
                     },
                     new TestTextShapeDefinition
                     {
                         Name = "Gross Margin",
                         Paragraphs = ["62%"],
-                        X = 3657600,
-                        Y = 1828800,
-                        Width = 1828800,
-                        Height = 685800
+                        X = Emu.Inches4,
+                        Y = Emu.Inches2,
+                        Width = Emu.Inches2,
+                        Height = Emu.ThreeQuartersInch
                     },
                     new TestTextShapeDefinition
                     {
@@ -210,19 +211,19 @@ public class UpdateSlideDataTests : PptxTestBase
                             new TestParagraphDefinition { Text = "Pipeline stable", IsBullet = true },
                             new TestParagraphDefinition { Text = "Upsell motion healthy", IsBullet = true }
                         ],
-                        X = 914400,
-                        Y = 2743200,
-                        Width = 3657600,
-                        Height = 1143000
+                        X = Emu.OneInch,
+                        Y = Emu.Inches3,
+                        Width = Emu.Inches4,
+                        Height = Emu.Inches1_25
                     },
                     new TestTextShapeDefinition
                     {
                         Name = "Owner Status",
                         Paragraphs = ["Amber"],
-                        X = 5029200,
-                        Y = 1828800,
-                        Width = 1371600,
-                        Height = 685800
+                        X = Emu.Inches5_5,
+                        Y = Emu.Inches2,
+                        Width = Emu.Inches1_5,
+                        Height = Emu.ThreeQuartersInch
                     }
                 ],
                 Tables =
@@ -236,10 +237,10 @@ public class UpdateSlideDataTests : PptxTestBase
                             ["NA", "3.2M"],
                             ["EMEA", "1.4M"]
                         ],
-                        X = 4572000,
-                        Y = 2743200,
-                        Width = 3657600,
-                        Height = 1371600
+                        X = Emu.Inches5,
+                        Y = Emu.Inches3,
+                        Width = Emu.Inches4,
+                        Height = Emu.Inches1_5
                     }
                 ],
                 IncludeImage = true

--- a/tests/PptxMcp.Tests/TemplateDeckHelper.cs
+++ b/tests/PptxMcp.Tests/TemplateDeckHelper.cs
@@ -24,9 +24,9 @@ internal static class TemplateDeckHelper
 
         titleBodyLayoutPart.SlideLayout = new SlideLayout(
             new CommonSlideData(CreateLayoutShapeTree(
-                CreatePlaceholderShape(2U, "Layout Title", PlaceholderValues.Title, 0U, 457200, 274320, 8229600, 685800, "Click to add title"),
-                CreatePlaceholderShape(3U, "Layout Body", PlaceholderValues.Body, 1U, 914400, 1600200, 7315200, 1371600, "Click to add text"),
-                CreatePlaceholderShape(4U, "Layout Body 2", PlaceholderValues.Body, 2U, 914400, 3200400, 7315200, 914400, "Click to add text"))),
+                CreatePlaceholderShape(2U, "Layout Title", PlaceholderValues.Title, 0U, Emu.HalfInch, Emu.Inches0_3, Emu.Inches9, Emu.ThreeQuartersInch, "Click to add title"),
+                CreatePlaceholderShape(3U, "Layout Body", PlaceholderValues.Body, 1U, Emu.OneInch, Emu.Inches1_75, Emu.Inches8, Emu.Inches1_5, "Click to add text"),
+                CreatePlaceholderShape(4U, "Layout Body 2", PlaceholderValues.Body, 2U, Emu.OneInch, Emu.Inches3_5, Emu.Inches8, Emu.OneInch, "Click to add text"))),
             new ColorMapOverride(new A.MasterColorMapping()))
         {
             Type = SlideLayoutValues.Text
@@ -35,9 +35,9 @@ internal static class TemplateDeckHelper
 
         pictureCaptionLayoutPart.SlideLayout = new SlideLayout(
             new CommonSlideData(CreateLayoutShapeTree(
-                CreatePlaceholderShape(2U, "Picture Layout Title", PlaceholderValues.Title, 0U, 457200, 274320, 8229600, 685800, "Click to add title"),
-                CreatePicturePlaceholder(3U, "Picture Placeholder", 1U, 914400, 1600200, 3657600, 2743200),
-                CreatePlaceholderShape(4U, "Picture Caption Body", PlaceholderValues.Body, 2U, 5029200, 1600200, 2743200, 1143000, "Click to add text"))),
+                CreatePlaceholderShape(2U, "Picture Layout Title", PlaceholderValues.Title, 0U, Emu.HalfInch, Emu.Inches0_3, Emu.Inches9, Emu.ThreeQuartersInch, "Click to add title"),
+                CreatePicturePlaceholder(3U, "Picture Placeholder", 1U, Emu.OneInch, Emu.Inches1_75, Emu.Inches4, Emu.Inches3),
+                CreatePlaceholderShape(4U, "Picture Caption Body", PlaceholderValues.Body, 2U, Emu.Inches5_5, Emu.Inches1_75, Emu.Inches3, Emu.Inches1_25, "Click to add text"))),
             new ColorMapOverride(new A.MasterColorMapping()))
         {
             Type = SlideLayoutValues.Text
@@ -79,8 +79,8 @@ internal static class TemplateDeckHelper
                     Id = 256U,
                     RelationshipId = presentationPart.GetIdOfPart(firstSlidePart)
                 }),
-            new SlideSize { Cx = 9144000, Cy = 6858000, Type = SlideSizeValues.Screen4x3 },
-            new NotesSize { Cx = 6858000, Cy = 9144000 });
+            new SlideSize { Cx = (int)Emu.Inches10, Cy = (int)Emu.Inches7_5, Type = SlideSizeValues.Screen4x3 },
+            new NotesSize { Cx = (int)Emu.Inches7_5, Cy = (int)Emu.Inches10 });
 
         presentationPart.Presentation.InsertAt(
             new SlideMasterIdList(
@@ -97,9 +97,9 @@ internal static class TemplateDeckHelper
     private static Slide CreateSourceSlide(SlidePart slidePart)
     {
         var shapeTree = CreateLayoutShapeTree(
-            CreatePlaceholderShape(2U, "Title 1", PlaceholderValues.Title, 0U, 457200, 274320, 8229600, 685800, "Quarterly Business Review"),
-            CreatePlaceholderShape(3U, "Body 1", PlaceholderValues.Body, 1U, 914400, 1600200, 7315200, 1371600, "Revenue up 12%", "EMEA stable"),
-            CreatePlaceholderShape(4U, "Body 2", PlaceholderValues.Body, 2U, 914400, 3200400, 7315200, 914400, "Follow-up items"));
+            CreatePlaceholderShape(2U, "Title 1", PlaceholderValues.Title, 0U, Emu.HalfInch, Emu.Inches0_3, Emu.Inches9, Emu.ThreeQuartersInch, "Quarterly Business Review"),
+            CreatePlaceholderShape(3U, "Body 1", PlaceholderValues.Body, 1U, Emu.OneInch, Emu.Inches1_75, Emu.Inches8, Emu.Inches1_5, "Revenue up 12%", "EMEA stable"),
+            CreatePlaceholderShape(4U, "Body 2", PlaceholderValues.Body, 2U, Emu.OneInch, Emu.Inches3_5, Emu.Inches8, Emu.OneInch, "Follow-up items"));
 
         var imagePart = slidePart.AddImagePart(ImagePartType.Png);
         using (var stream = new MemoryStream(SampleImageBytes))
@@ -107,8 +107,8 @@ internal static class TemplateDeckHelper
 
         var imageRelationshipId = slidePart.GetIdOfPart(imagePart);
 
-        shapeTree.Append(CreatePicture(5U, imageRelationshipId, 5486400, 1600200, 2286000, 1828800));
-        shapeTree.Append(CreatePicture(6U, imageRelationshipId, 5486400, 3657600, 1828800, 1371600));
+        shapeTree.Append(CreatePicture(5U, imageRelationshipId, Emu.Inches6, Emu.Inches1_75, Emu.Inches2_5, Emu.Inches2));
+        shapeTree.Append(CreatePicture(6U, imageRelationshipId, Emu.Inches6, Emu.Inches4, Emu.Inches2, Emu.Inches1_5));
 
         return new Slide(
             new CommonSlideData(shapeTree),

--- a/tests/PptxMcp.Tests/TestPptxHelper.cs
+++ b/tests/PptxMcp.Tests/TestPptxHelper.cs
@@ -95,8 +95,8 @@ internal static class TestPptxHelper
 
         presentationPart.Presentation = new Presentation(
             slideIdList,
-            new SlideSize { Cx = 9144000, Cy = 6858000, Type = SlideSizeValues.Screen4x3 },
-            new NotesSize { Cx = 6858000, Cy = 9144000 });
+            new SlideSize { Cx = (int)Emu.Inches10, Cy = (int)Emu.Inches7_5, Type = SlideSizeValues.Screen4x3 },
+            new NotesSize { Cx = (int)Emu.Inches7_5, Cy = (int)Emu.Inches10 });
 
         var slideMasterIdList = new SlideMasterIdList(
             new SlideMasterId
@@ -127,50 +127,50 @@ internal static class TestPptxHelper
                 "Title 1",
                 [new TestParagraphDefinition { Text = slideDefinition.TitleText }],
                 PlaceholderValues.CenteredTitle,
-                457200,
-                274320,
-                8229600,
-                685800));
+                Emu.HalfInch,
+                Emu.Inches0_3,
+                Emu.Inches9,
+                Emu.ThreeQuartersInch));
         }
 
-        long currentY = 1371600;
+        long currentY = Emu.Inches1_5;
         foreach (var textShape in slideDefinition.TextShapes)
         {
             var paragraphDefinitions = textShape.ParagraphDefinitions.Count > 0
                 ? textShape.ParagraphDefinitions
                 : textShape.Paragraphs.Select(paragraph => new TestParagraphDefinition { Text = paragraph }).ToList();
 
-            long height = textShape.Height ?? Math.Max(685800, 342900L * Math.Max(1, paragraphDefinitions.Count));
+            long height = textShape.Height ?? Math.Max(Emu.ThreeQuartersInch, Emu.ThreeEighthsInch * Math.Max(1, paragraphDefinitions.Count));
             shapeTree.Append(CreateTextShape(
                 nextShapeId,
                 string.IsNullOrWhiteSpace(textShape.Name) ? $"Text {nextShapeId}" : textShape.Name!,
                 paragraphDefinitions,
                 textShape.PlaceholderType,
-                textShape.X ?? 914400,
+                textShape.X ?? Emu.OneInch,
                 textShape.Y ?? currentY,
-                textShape.Width ?? 7315200,
+                textShape.Width ?? Emu.Inches8,
                 height));
             nextShapeId++;
 
             if (textShape.Y is null)
-                currentY += height + 228600;
+                currentY += height + Emu.QuarterInch;
         }
 
         foreach (var table in slideDefinition.Tables)
         {
-            long height = table.Height ?? 1371600;
+            long height = table.Height ?? Emu.Inches1_5;
             shapeTree.Append(CreateTable(
                 nextShapeId,
                 string.IsNullOrWhiteSpace(table.Name) ? $"Table {nextShapeId}" : table.Name!,
                 table,
-                table.X ?? 914400,
+                table.X ?? Emu.OneInch,
                 table.Y ?? currentY,
-                table.Width ?? 7315200,
+                table.Width ?? Emu.Inches8,
                 height));
             nextShapeId++;
 
             if (table.Y is null)
-                currentY += height + 228600;
+                currentY += height + Emu.QuarterInch;
         }
 
         var slide = new Slide(
@@ -186,10 +186,10 @@ internal static class TestPptxHelper
             shapeTree.Append(CreatePicture(
                 nextShapeId++,
                 slidePart.GetIdOfPart(imagePart),
-                914400,
+                Emu.OneInch,
                 currentY,
-                3657600,
-                2743200));
+                Emu.Inches4,
+                Emu.Inches3));
         }
 
         return slide;
@@ -281,7 +281,7 @@ internal static class TestPptxHelper
             ? new List<List<string>> { new() { string.Empty } }
             : table.Rows.Select(row => row.Count == 0 ? new List<string> { string.Empty } : row.ToList()).ToList();
         var columnCount = rows.Max(row => row.Count);
-        var rowHeight = Math.Max(342900L, height / rows.Count);
+        var rowHeight = Math.Max(Emu.ThreeEighthsInch, height / rows.Count);
         var columnWidth = Math.Max(1L, width / columnCount);
 
         var drawingTable = new A.Table(new A.TableProperties { FirstRow = true, BandRow = true });

--- a/tests/PptxMcp.Tests/Tools/ImageReplaceToolTests.cs
+++ b/tests/PptxMcp.Tests/Tools/ImageReplaceToolTests.cs
@@ -6,6 +6,7 @@ using P = DocumentFormat.OpenXml.Presentation;
 
 namespace PptxMcp.Tests.Tools;
 
+[Trait("Category", "Integration")]
 public class ImageReplaceToolTests : PptxTestBase
 {
     private readonly PptxTools _tools;
@@ -88,8 +89,8 @@ public class ImageReplaceToolTests : PptxTestBase
 
         presentationPart.Presentation = new Presentation(
             new SlideIdList(new SlideId { Id = 256, RelationshipId = presentationPart.GetIdOfPart(slidePart) }),
-            new SlideSize { Cx = 9144000, Cy = 6858000, Type = SlideSizeValues.Screen4x3 },
-            new NotesSize { Cx = 6858000, Cy = 9144000 });
+            new SlideSize { Cx = (int)Emu.Inches10, Cy = (int)Emu.Inches7_5, Type = SlideSizeValues.Screen4x3 },
+            new NotesSize { Cx = (int)Emu.Inches7_5, Cy = (int)Emu.Inches10 });
         presentationPart.Presentation.InsertAt(
             new SlideMasterIdList(new SlideMasterId { Id = 2147483648U, RelationshipId = presentationPart.GetIdOfPart(slideMasterPart) }), 0);
         presentationPart.Presentation.Save();

--- a/tests/PptxMcp.Tests/Tools/PptxExportMarkdownToolTests.cs
+++ b/tests/PptxMcp.Tests/Tools/PptxExportMarkdownToolTests.cs
@@ -1,5 +1,6 @@
 namespace PptxMcp.Tests.Tools;
 
+[Trait("Category", "Integration")]
 public class PptxExportMarkdownToolTests : PptxTestBase
 {
     private readonly PptxTools _tools;

--- a/tests/PptxMcp.Tests/Tools/PptxPhase1E2eTests.cs
+++ b/tests/PptxMcp.Tests/Tools/PptxPhase1E2eTests.cs
@@ -4,6 +4,7 @@ using DocumentFormat.OpenXml.Presentation;
 
 namespace PptxMcp.Tests.Tools;
 
+[Trait("Category", "E2E")]
 public class PptxPhase1E2eTests : PptxTestBase
 {
     private readonly PptxTools _tools;

--- a/tests/PptxMcp.Tests/Tools/PptxPhase2E2eTests.cs
+++ b/tests/PptxMcp.Tests/Tools/PptxPhase2E2eTests.cs
@@ -5,6 +5,7 @@ using DocumentFormat.OpenXml.Validation;
 
 namespace PptxMcp.Tests.Tools;
 
+[Trait("Category", "E2E")]
 public class PptxPhase2E2eTests : PptxTestBase
 {
     private readonly PptxTools _tools;

--- a/tests/PptxMcp.Tests/Tools/PptxToolsTests.cs
+++ b/tests/PptxMcp.Tests/Tools/PptxToolsTests.cs
@@ -4,6 +4,7 @@ using PptxMcp.Models;
 
 namespace PptxMcp.Tests.Tools;
 
+[Trait("Category", "Integration")]
 public class PptxToolsTests : PptxTestBase
 {
     private readonly PptxTools _tools;

--- a/tests/PptxMcp.Tests/Tools/TableToolsTests.cs
+++ b/tests/PptxMcp.Tests/Tools/TableToolsTests.cs
@@ -7,6 +7,7 @@ namespace PptxMcp.Tests.Tools;
 /// Written proactively for Issue #36 — table insert and update tools.
 /// These tests verify JSON output format, error handling, and parameter validation at the MCP tool layer.
 /// </summary>
+[Trait("Category", "Integration")]
 public class TableToolsTests : PptxTestBase
 {
     private readonly PptxTools _tools;


### PR DESCRIPTION
## Summary

### Issue #68: Add test categories
Added `[Trait("Category", "...")]` attributes to all 17 test classes:
- **Unit** (8 classes): PresentationServiceTests, SlideOrganizationTests, MarkdownExportTests, UpdateSlideDataTests, BatchUpdateTests, TemplateSlideTests, TableOperationTests, ImageReplaceTests
- **Integration** (7 classes): PptxToolsTests, TableToolsTests, PptxExportMarkdownToolTests, ImageReplaceToolTests, PptxCompletionHandlerTests, PptxPromptsTests, PptxResourcesTests
- **E2E** (2 classes): PptxPhase1E2eTests, PptxPhase2E2eTests

Enables filtered execution: `dotnet test -- --filter-trait "Category=Unit"`

### Issue #70: Extract EMU constants
Created `tests/PptxMcp.Tests/EmuConstants.cs` with 21 named constants (`QuarterInch` through `Inches10`), each with XML doc comments explaining the measurement. Replaced all hardcoded EMU magic numbers across 6 files:
- TestPptxHelper.cs, TemplateDeckHelper.cs
- UpdateSlideDataTests.cs, BatchUpdateTests.cs, ImageReplaceTests.cs, ImageReplaceToolTests.cs

### Verification
- 260/260 tests passing
- Zero build errors

Closes #68, closes #70