### PR TITLE
Add pptx_deduplicate_media tool (#84)

### DIFF
--- a/.squad/agents/cheritto/history.md
+++ b/.squad/agents/cheritto/history.md
@@ -135,3 +135,22 @@
 - Categorization uses URI patterns first (/ppt/slides/, /ppt/slideMasters/, /ppt/slideLayouts/) then content type fallback (image/*, video/*, audio/*) for media
 - 160 lines across 3 new files; 418/418 existing tests still passing
 - No tests included (Shiherlis owns test creation per team charter)
+
+### Issue #83 — pptx_remove_unused_layouts (2026-03-24)
+- **Implementation:** First Phase 4 Tier 2 write operation — removes unused slide layouts and orphaned masters from PPTX files
+- **Approach:** Two-phase: read-only analysis via FindUnusedLayouts(), then writable open for targeted deletion with OpenXmlValidator before/after
+- **Safety:** Intersects caller-specified URIs with actually-unused set; never removes a layout referenced by any slide; removes masters only when zero layouts remain
+- **Key helpers:** RemoveLayoutIdFromMaster() and RemoveMasterIdFromPresentation() clean up SlideLayoutIdList and SlideMasterIdList entries before deleting parts
+- **Model:** RemoveLayoutsResult with RemovedItemInfo and ValidationStatus records — captures before/after validation error counts
+- **Tests:** 733-line RemoveLayoutsTests.cs included (auto-detect, targeted, no-op, error cases)
+- **Build:** 0 errors, 0 warnings; 532/532 tests passing
+- **PR:** #90 on branch squad/83-remove-unused-layouts
+
+### Issue #84 — pptx_deduplicate_media (2026-03-24)
+- **Implementation:** Phase 4 Tier 2 write operation — deduplicates identical media by SHA256 hash, redirects references, removes orphaned copies
+- **Approach:** Hash all ImageParts across slides/layouts/masters → group by hash → pick canonical (alphabetically first URI) → redirect Blip.Embed references via CreateRelationshipToPart → DeletePart orphaned duplicates
+- **Key detail:** Relationship redirect requires collecting all (owner, oldRelId) pairs BEFORE modifying anything, then updating Blip.Embed in each owner, then deleting old relationships — order matters for package integrity
+- **Model:** DeduplicateMediaResult with DeduplicatedGroupInfo; reuses ValidationStatus from RemoveLayoutsResult.cs
+- **Files:** PresentationService.Deduplication.cs (new partial), PptxTools.Deduplication.cs, DeduplicateMediaResult.cs, DeduplicateMediaTests.cs
+- **Build:** 0 errors; 542/542 tests passing (10 new tests)
+- **PR:** on branch squad/84-deduplicate-media

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ See [docs/QUICKSTART.md](docs/QUICKSTART.md) for a full walkthrough.
 | `pptx_analyze_media` | List and analyze all media assets (images, video, audio) with duplicate detection |
 | `pptx_find_unused_layouts` | Find unused slide masters and layouts with estimated space savings |
 | `pptx_remove_unused_layouts` | Remove unused slide layouts and orphaned masters with before/after validation |
+| `pptx_deduplicate_media` | Deduplicate identical media by hash, redirect references, remove orphaned copies |
 
 **When to use `pptx_update_slide_data` vs `pptx_update_text`:** Use `pptx_update_slide_data` when shapes have descriptive names (check `pptx_get_slide_content`) — it targets shapes by name and preserves their existing formatting. Use `pptx_update_text` for anonymous placeholders identified only by index.
 

--- a/docs/TOOL_REFERENCE.md
+++ b/docs/TOOL_REFERENCE.md
@@ -17,6 +17,7 @@ Complete reference for all MCP tools exposed by pptx-mcp, organized alphabetical
 - [pptx_extract_talking_points](#pptx_extract_talking_points)
 - [pptx_find_unused_layouts](#pptx_find_unused_layouts)
 - [pptx_remove_unused_layouts](#pptx_remove_unused_layouts)
+- [pptx_deduplicate_media](#pptx_deduplicate_media)
 - [pptx_get_slide_content](#pptx_get_slide_content)
 - [pptx_get_slide_xml](#pptx_get_slide_xml)
 - [pptx_insert_image](#pptx_insert_image)
@@ -701,6 +702,61 @@ On error, returns the same structure with `Success: false` and empty lists.
       "/ppt/slideLayouts/slideLayout4.xml",
       "/ppt/slideLayouts/slideLayout7.xml"
     ]
+  }
+}
+```
+
+---
+
+## pptx_deduplicate_media
+
+**Description:** Deduplicate identical media in a PowerPoint presentation. Finds media parts with the same content (SHA256 hash match), redirects all references to a single canonical copy, and removes orphaned duplicates. Validates the package with OpenXmlValidator before and after modification. Returns structured JSON with deduplication statistics and space saved.
+
+### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `filePath` | string | ✅ Required | Absolute or relative path to the .pptx file to modify. |
+
+### Returns
+
+Structured JSON with deduplication results and validation status:
+
+```json
+{
+  "Success": true,
+  "FilePath": "/presentations/quarterly-review.pptx",
+  "DuplicateGroupsFound": 1,
+  "PartsRemoved": 1,
+  "BytesSaved": 45200,
+  "Groups": [
+    {
+      "Hash": "A1B2C3D4...",
+      "ContentType": "image/png",
+      "CanonicalPartUri": "/ppt/media/image1.png",
+      "RemovedPartUris": ["/ppt/media/image3.png"],
+      "SizePerCopy": 45200,
+      "ReferencesUpdated": 1
+    }
+  ],
+  "Validation": {
+    "ErrorsBefore": 0,
+    "ErrorsAfter": 0,
+    "IsValid": true
+  },
+  "Message": "Deduplicated 1 group(s), removed 1 part(s). Saved approximately 45,200 bytes."
+}
+```
+
+On error, returns the same structure with `Success: false` and empty lists.
+
+### Example
+
+```json
+{
+  "name": "pptx_deduplicate_media",
+  "arguments": {
+    "filePath": "/presentations/quarterly-review.pptx"
   }
 }
 ```

--- a/src/PptxMcp/Models/DeduplicateMediaResult.cs
+++ b/src/PptxMcp/Models/DeduplicateMediaResult.cs
@@ -1,0 +1,35 @@
+namespace PptxMcp.Models;
+
+/// <summary>Structured result for pptx_deduplicate_media.</summary>
+/// <param name="Success">True when deduplication completed successfully.</param>
+/// <param name="FilePath">Path to the modified presentation file.</param>
+/// <param name="DuplicateGroupsFound">Number of groups containing identical media (same SHA256 hash).</param>
+/// <param name="PartsRemoved">Total number of duplicate media parts removed.</param>
+/// <param name="BytesSaved">Total bytes saved by removing duplicate parts.</param>
+/// <param name="Groups">Details for each deduplicated group.</param>
+/// <param name="Validation">OpenXML validation status before and after.</param>
+/// <param name="Message">Human-readable status or error message.</param>
+public record DeduplicateMediaResult(
+    bool Success,
+    string FilePath,
+    int DuplicateGroupsFound,
+    int PartsRemoved,
+    long BytesSaved,
+    IReadOnlyList<DeduplicatedGroupInfo> Groups,
+    ValidationStatus Validation,
+    string Message);
+
+/// <summary>Details about a single group of deduplicated media.</summary>
+/// <param name="Hash">SHA256 hex hash shared by all parts in this group.</param>
+/// <param name="ContentType">MIME content type of the media.</param>
+/// <param name="CanonicalPartUri">URI of the canonical (kept) part.</param>
+/// <param name="RemovedPartUris">URIs of the removed duplicate parts.</param>
+/// <param name="SizePerCopy">Size of each individual copy in bytes.</param>
+/// <param name="ReferencesUpdated">Number of relationship references redirected to the canonical part.</param>
+public record DeduplicatedGroupInfo(
+    string Hash,
+    string ContentType,
+    string CanonicalPartUri,
+    string[] RemovedPartUris,
+    long SizePerCopy,
+    int ReferencesUpdated);

--- a/src/PptxMcp/Services/PresentationService.Deduplication.cs
+++ b/src/PptxMcp/Services/PresentationService.Deduplication.cs
@@ -1,0 +1,211 @@
+using System.Security.Cryptography;
+using DocumentFormat.OpenXml.Drawing;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Validation;
+using PptxMcp.Models;
+
+namespace PptxMcp.Services;
+
+public partial class PresentationService
+{
+    /// <summary>
+    /// Deduplicate identical media parts in a PPTX file.
+    /// Finds media with the same SHA256 hash, redirects all references to a single canonical copy,
+    /// and removes the orphaned duplicates. Validates the package before and after modification.
+    /// </summary>
+    public DeduplicateMediaResult DeduplicateMedia(string filePath)
+    {
+        using var doc = PresentationDocument.Open(filePath, true);
+        var presentationPart = doc.PresentationPart
+            ?? throw new InvalidOperationException("Presentation part is missing.");
+
+        var validator = new OpenXmlValidator();
+        int errorsBefore = validator.Validate(doc).Count();
+
+        // Phase 1: Build hash→ImageParts map across all owning parts.
+        var hashToImageParts = new Dictionary<string, List<(ImagePart Part, string Uri)>>();
+        var allOwnerParts = CollectAllOwnerParts(presentationPart);
+
+        // Track which ImagePart URIs we've already hashed (same part referenced by multiple owners).
+        var hashedUris = new Dictionary<string, string>(); // uri → hash
+
+        foreach (var ownerPart in allOwnerParts)
+        {
+            foreach (var idPartPair in ownerPart.Parts)
+            {
+                if (idPartPair.OpenXmlPart is not ImagePart imagePart)
+                    continue;
+
+                var uri = imagePart.Uri.ToString();
+                if (!hashedUris.TryGetValue(uri, out var hash))
+                {
+                    using var stream = imagePart.GetStream();
+                    using var ms = new MemoryStream();
+                    stream.CopyTo(ms);
+                    ms.Position = 0;
+                    hash = Convert.ToHexString(SHA256.HashData(ms));
+                    hashedUris[uri] = hash;
+                }
+
+                if (!hashToImageParts.TryGetValue(hash, out var list))
+                {
+                    list = [];
+                    hashToImageParts[hash] = list;
+                }
+
+                // Only add each URI once to the group.
+                if (!list.Any(x => x.Uri == uri))
+                    list.Add((imagePart, uri));
+            }
+        }
+
+        // Phase 2: For each duplicate group, pick canonical and redirect references.
+        var groups = new List<DeduplicatedGroupInfo>();
+        int totalPartsRemoved = 0;
+        long totalBytesSaved = 0;
+
+        foreach (var (hash, parts) in hashToImageParts)
+        {
+            if (parts.Count < 2)
+                continue;
+
+            // Canonical = first alphabetically by URI.
+            var sorted = parts.OrderBy(p => p.Uri, StringComparer.OrdinalIgnoreCase).ToList();
+            var canonical = sorted[0];
+            var duplicates = sorted.Skip(1).ToList();
+
+            long sizePerCopy = 0;
+            try
+            {
+                using var s = canonical.Part.GetStream();
+                sizePerCopy = s.Length;
+            }
+            catch { }
+
+            int referencesUpdated = 0;
+            var removedUris = new List<string>();
+
+            foreach (var dup in duplicates)
+            {
+                // Collect owners that reference this duplicate before modifying anything.
+                var ownersWithDup = new List<(OpenXmlPart Owner, string OldRelId)>();
+                foreach (var ownerPart in allOwnerParts)
+                {
+                    var oldRelId = FindRelationshipId(ownerPart, dup.Part);
+                    if (oldRelId is not null)
+                        ownersWithDup.Add((ownerPart, oldRelId));
+                }
+
+                // Redirect each owner's references from duplicate to canonical.
+                foreach (var (ownerPart, oldRelId) in ownersWithDup)
+                {
+                    var newRelId = FindRelationshipId(ownerPart, canonical.Part)
+                        ?? ownerPart.CreateRelationshipToPart(canonical.Part);
+
+                    referencesUpdated += UpdateBlipReferences(ownerPart, oldRelId, newRelId);
+                }
+
+                // Now remove the duplicate part from each owner that had it.
+                // DeletePart removes the relationship; the part is removed when the last ref goes.
+                foreach (var (ownerPart, _) in ownersWithDup)
+                {
+                    if (ownerPart.Parts.Any(p => p.OpenXmlPart == dup.Part))
+                        ownerPart.DeletePart(dup.Part);
+                }
+
+                removedUris.Add(dup.Uri);
+                totalBytesSaved += sizePerCopy;
+                totalPartsRemoved++;
+            }
+
+            groups.Add(new DeduplicatedGroupInfo(
+                Hash: hash,
+                ContentType: canonical.Part.ContentType,
+                CanonicalPartUri: canonical.Uri,
+                RemovedPartUris: removedUris.ToArray(),
+                SizePerCopy: sizePerCopy,
+                ReferencesUpdated: referencesUpdated));
+        }
+
+        // Phase 4: Save and validate after modification.
+        presentationPart.Presentation.Save();
+        int errorsAfter = validator.Validate(doc).Count();
+
+        string message = groups.Count > 0
+            ? $"Deduplicated {groups.Count} group(s), removed {totalPartsRemoved} part(s). Saved approximately {totalBytesSaved:N0} bytes."
+            : "No duplicate media found.";
+
+        return new DeduplicateMediaResult(
+            Success: true,
+            FilePath: filePath,
+            DuplicateGroupsFound: groups.Count,
+            PartsRemoved: totalPartsRemoved,
+            BytesSaved: totalBytesSaved,
+            Groups: groups,
+            Validation: new ValidationStatus(errorsBefore, errorsAfter, errorsAfter == 0),
+            Message: message);
+    }
+
+    /// <summary>Collect all parts that may own media relationships (slides, layouts, masters).</summary>
+    private static List<OpenXmlPart> CollectAllOwnerParts(PresentationPart presentationPart)
+    {
+        var owners = new List<OpenXmlPart>();
+
+        var slideIds = presentationPart.Presentation.SlideIdList
+            ?.Elements<DocumentFormat.OpenXml.Presentation.SlideId>() ?? [];
+        foreach (var slideId in slideIds)
+        {
+            if (slideId.RelationshipId?.Value is { } relId &&
+                presentationPart.GetPartById(relId) is OpenXmlPart slidePart)
+            {
+                owners.Add(slidePart);
+            }
+        }
+
+        foreach (var masterPart in presentationPart.SlideMasterParts)
+        {
+            owners.Add(masterPart);
+            foreach (var layoutPart in masterPart.SlideLayoutParts)
+                owners.Add(layoutPart);
+        }
+
+        return owners;
+    }
+
+    /// <summary>Find the relationship ID that an owner part uses to reference a target part, or null.</summary>
+    private static string? FindRelationshipId(OpenXmlPart ownerPart, OpenXmlPart targetPart)
+    {
+        foreach (var idPart in ownerPart.Parts)
+        {
+            if (idPart.OpenXmlPart == targetPart)
+                return idPart.RelationshipId;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Update all Blip.Embed attributes in an owner part's XML tree from oldRelId to newRelId.
+    /// Returns the number of references updated.
+    /// </summary>
+    private static int UpdateBlipReferences(OpenXmlPart ownerPart, string oldRelId, string newRelId)
+    {
+        var rootElement = ownerPart.RootElement;
+        if (rootElement is null)
+            return 0;
+
+        int count = 0;
+        foreach (var blip in rootElement.Descendants<Blip>())
+        {
+            if (blip.Embed?.Value == oldRelId)
+            {
+                blip.Embed = newRelId;
+                count++;
+            }
+        }
+
+        if (count > 0)
+            rootElement.Save();
+
+        return count;
+    }
+}

--- a/src/PptxMcp/Tools/PptxTools.Deduplication.cs
+++ b/src/PptxMcp/Tools/PptxTools.Deduplication.cs
@@ -1,0 +1,29 @@
+using ModelContextProtocol.Server;
+using PptxMcp.Models;
+
+namespace PptxMcp.Tools;
+
+public partial class PptxTools
+{
+    /// <summary>
+    /// Deduplicate identical media in a PowerPoint presentation.
+    /// Finds media parts with the same content (SHA256 hash match), redirects all references
+    /// to a single canonical copy, and removes orphaned duplicates.
+    /// Validates the package with OpenXmlValidator before and after modification.
+    /// Returns structured JSON with deduplication statistics and space saved.
+    /// </summary>
+    /// <param name="filePath">Absolute or relative path to the .pptx file to modify.</param>
+    [McpServerTool(Title = "Deduplicate Media")]
+    public partial Task<string> pptx_deduplicate_media(string filePath) =>
+        ExecuteToolStructured(filePath,
+            () => _service.DeduplicateMedia(filePath),
+            error => new DeduplicateMediaResult(
+                Success: false,
+                FilePath: filePath,
+                DuplicateGroupsFound: 0,
+                PartsRemoved: 0,
+                BytesSaved: 0,
+                Groups: [],
+                Validation: new ValidationStatus(0, 0, false),
+                Message: error));
+}

--- a/tests/PptxMcp.Tests/Services/DeduplicateMediaTests.cs
+++ b/tests/PptxMcp.Tests/Services/DeduplicateMediaTests.cs
@@ -1,0 +1,593 @@
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Drawing;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Presentation;
+using A = DocumentFormat.OpenXml.Drawing;
+using P = DocumentFormat.OpenXml.Presentation;
+
+namespace PptxMcp.Tests.Services;
+
+/// <summary>
+/// Service-level tests for DeduplicateMedia (Issue #84 — Deduplicate identical media).
+/// Validates deduplication correctness, reference integrity, validation, and round-trip safety.
+/// </summary>
+[Trait("Category", "Unit")]
+public class DeduplicateMediaTests : PptxTestBase
+{
+    // ──────────────────────────────────────────────────────────
+    //  1. No duplicates — file unchanged, 0 parts removed
+    // ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void DeduplicateMedia_NoDuplicates_ReturnsNoOp()
+    {
+        var path = CreatePptxWithUniqueImages(imageCount: 2);
+
+        var result = Service.DeduplicateMedia(path);
+
+        Assert.True(result.Success);
+        Assert.Equal(0, result.DuplicateGroupsFound);
+        Assert.Equal(0, result.PartsRemoved);
+        Assert.Equal(0, result.BytesSaved);
+        Assert.Empty(result.Groups);
+    }
+
+    // ──────────────────────────────────────────────────────────
+    //  2. Two identical images on different slides — one removed
+    // ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void DeduplicateMedia_TwoIdenticalImages_RemovesOne()
+    {
+        var path = CreatePptxWithDuplicateImage();
+
+        var result = Service.DeduplicateMedia(path);
+
+        Assert.True(result.Success);
+        Assert.Equal(1, result.DuplicateGroupsFound);
+        Assert.Equal(1, result.PartsRemoved);
+        Assert.True(result.BytesSaved > 0);
+        Assert.Single(result.Groups);
+
+        var group = result.Groups[0];
+        Assert.Single(group.RemovedPartUris);
+        Assert.NotEqual(group.CanonicalPartUri, group.RemovedPartUris[0]);
+    }
+
+    // ──────────────────────────────────────────────────────────
+    //  3. Multiple duplicate groups — all deduplicated
+    // ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void DeduplicateMedia_MultipleDuplicateGroups_AllDeduplicated()
+    {
+        var path = CreatePptxWithMultipleDuplicateGroups();
+
+        var result = Service.DeduplicateMedia(path);
+
+        Assert.True(result.Success);
+        Assert.Equal(2, result.DuplicateGroupsFound);
+        Assert.Equal(2, result.PartsRemoved);
+        Assert.True(result.BytesSaved > 0);
+        Assert.Equal(2, result.Groups.Count);
+    }
+
+    // ──────────────────────────────────────────────────────────
+    //  4. Validates before and after — no new errors
+    // ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void DeduplicateMedia_ValidatesBeforeAndAfter()
+    {
+        var path = CreatePptxWithDuplicateImage();
+
+        var result = Service.DeduplicateMedia(path);
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Validation);
+        Assert.True(result.Validation.ErrorsBefore >= 0);
+        Assert.True(result.Validation.ErrorsAfter <= result.Validation.ErrorsBefore,
+            "Deduplication should not introduce new validation errors.");
+    }
+
+    // ──────────────────────────────────────────────────────────
+    //  5. Round-trip — file opens in OpenXml after dedup
+    // ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void DeduplicateMedia_FileOpensInOpenXml_AfterDedup()
+    {
+        var path = CreatePptxWithDuplicateImage();
+
+        var result = Service.DeduplicateMedia(path);
+        Assert.True(result.Success);
+
+        // Re-open and verify structural integrity
+        using var doc = PresentationDocument.Open(path, false);
+        var presentationPart = doc.PresentationPart;
+        Assert.NotNull(presentationPart);
+
+        var slideIdList = presentationPart.Presentation.SlideIdList;
+        Assert.NotNull(slideIdList);
+        Assert.NotEmpty(slideIdList.Elements<SlideId>());
+    }
+
+    // ──────────────────────────────────────────────────────────
+    //  6. References updated — Blip.Embed points to canonical
+    // ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void DeduplicateMedia_BlipReferencesPointToCanonical()
+    {
+        var path = CreatePptxWithDuplicateImage();
+
+        var result = Service.DeduplicateMedia(path);
+        Assert.True(result.Success);
+        Assert.Single(result.Groups);
+
+        var canonicalUri = result.Groups[0].CanonicalPartUri;
+
+        // Verify all slide images reference the canonical part
+        using var doc = PresentationDocument.Open(path, false);
+        var presentationPart = doc.PresentationPart!;
+
+        foreach (var slideId in presentationPart.Presentation.SlideIdList!.Elements<SlideId>())
+        {
+            var slidePart = (SlidePart)presentationPart.GetPartById(slideId.RelationshipId!.Value!);
+            var blips = slidePart.Slide.Descendants<Blip>();
+            foreach (var blip in blips)
+            {
+                if (blip.Embed?.Value is { } relId &&
+                    slidePart.TryGetPartById(relId, out var part) &&
+                    part is ImagePart imagePart)
+                {
+                    Assert.Equal(canonicalUri, imagePart.Uri.ToString());
+                }
+            }
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────
+    //  7. Image on layout — still handled
+    // ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void DeduplicateMedia_ImageOnLayout_StillDeduplicated()
+    {
+        var path = CreatePptxWithDuplicateImageOnLayout();
+
+        var result = Service.DeduplicateMedia(path);
+
+        Assert.True(result.Success);
+        Assert.Equal(1, result.DuplicateGroupsFound);
+        Assert.Equal(1, result.PartsRemoved);
+    }
+
+    // ──────────────────────────────────────────────────────────
+    //  8. FilePath matches input
+    // ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void DeduplicateMedia_FilePath_MatchesInput()
+    {
+        var path = CreatePptxWithDuplicateImage();
+
+        var result = Service.DeduplicateMedia(path);
+
+        Assert.Equal(path, result.FilePath);
+    }
+
+    // ──────────────────────────────────────────────────────────
+    //  9. Message is populated
+    // ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void DeduplicateMedia_Message_IsNotEmpty()
+    {
+        var path = CreatePptxWithDuplicateImage();
+
+        var result = Service.DeduplicateMedia(path);
+
+        Assert.False(string.IsNullOrWhiteSpace(result.Message));
+    }
+
+    // ──────────────────────────────────────────────────────────
+    //  10. Media count decreases after dedup
+    // ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void DeduplicateMedia_MediaCountDecreases()
+    {
+        var path = CreatePptxWithDuplicateImage();
+
+        var analysisBefore = Service.AnalyzeMedia(path);
+        var result = Service.DeduplicateMedia(path);
+        var analysisAfter = Service.AnalyzeMedia(path);
+
+        Assert.True(result.Success);
+        Assert.True(analysisAfter.TotalMediaCount < analysisBefore.TotalMediaCount,
+            "Media count should decrease after deduplication.");
+    }
+
+    // ──────────────────────────────────────────────────────────
+    //  Helpers — create PPTX fixtures with specific media patterns
+    // ──────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Creates a PPTX with the specified number of slides, each having a unique image.
+    /// </summary>
+    private string CreatePptxWithUniqueImages(int imageCount)
+    {
+        var path = System.IO.Path.Join(System.IO.Path.GetTempPath(), System.IO.Path.GetRandomFileName() + ".pptx");
+        TrackTempFile(path);
+
+        using var doc = PresentationDocument.Create(path, PresentationDocumentType.Presentation);
+        var presentationPart = doc.AddPresentationPart();
+        var (slideMasterPart, slideLayoutPart) = CreateMinimalMasterAndLayout(presentationPart);
+
+        var slideIdList = new SlideIdList();
+        uint slideId = 256;
+
+        for (int i = 0; i < imageCount; i++)
+        {
+            var slidePart = presentationPart.AddNewPart<SlidePart>();
+            slidePart.AddPart(slideLayoutPart);
+
+            // Create a unique image (different pixel for each)
+            var imagePart = slidePart.AddImagePart(ImagePartType.Png);
+            var imageBytes = CreatePngImage((byte)(i + 1));
+            using (var ms = new MemoryStream(imageBytes))
+                imagePart.FeedData(ms);
+
+            var relId = slidePart.GetIdOfPart(imagePart);
+            slidePart.Slide = CreateSlideWithPicture(relId);
+
+            slideIdList.Append(new SlideId
+            {
+                Id = slideId++,
+                RelationshipId = presentationPart.GetIdOfPart(slidePart)
+            });
+        }
+
+        FinalizePresentationPart(presentationPart, slideIdList, slideMasterPart);
+        return path;
+    }
+
+    /// <summary>
+    /// Creates a PPTX with 2 slides, both referencing identical (but separate) image parts.
+    /// </summary>
+    private string CreatePptxWithDuplicateImage()
+    {
+        var path = System.IO.Path.Join(System.IO.Path.GetTempPath(), System.IO.Path.GetRandomFileName() + ".pptx");
+        TrackTempFile(path);
+
+        var imageBytes = CreatePngImage(0xAA);
+
+        using var doc = PresentationDocument.Create(path, PresentationDocumentType.Presentation);
+        var presentationPart = doc.AddPresentationPart();
+        var (slideMasterPart, slideLayoutPart) = CreateMinimalMasterAndLayout(presentationPart);
+
+        var slideIdList = new SlideIdList();
+        uint slideId = 256;
+
+        for (int i = 0; i < 2; i++)
+        {
+            var slidePart = presentationPart.AddNewPart<SlidePart>();
+            slidePart.AddPart(slideLayoutPart);
+
+            var imagePart = slidePart.AddImagePart(ImagePartType.Png);
+            using (var ms = new MemoryStream(imageBytes))
+                imagePart.FeedData(ms);
+
+            var relId = slidePart.GetIdOfPart(imagePart);
+            slidePart.Slide = CreateSlideWithPicture(relId);
+
+            slideIdList.Append(new SlideId
+            {
+                Id = slideId++,
+                RelationshipId = presentationPart.GetIdOfPart(slidePart)
+            });
+        }
+
+        FinalizePresentationPart(presentationPart, slideIdList, slideMasterPart);
+        return path;
+    }
+
+    /// <summary>
+    /// Creates a PPTX with 4 slides and 2 duplicate groups (2 pairs of identical images).
+    /// </summary>
+    private string CreatePptxWithMultipleDuplicateGroups()
+    {
+        var path = System.IO.Path.Join(System.IO.Path.GetTempPath(), System.IO.Path.GetRandomFileName() + ".pptx");
+        TrackTempFile(path);
+
+        var imageA = CreatePngImage(0xAA);
+        var imageB = CreatePngImage(0xBB);
+
+        using var doc = PresentationDocument.Create(path, PresentationDocumentType.Presentation);
+        var presentationPart = doc.AddPresentationPart();
+        var (slideMasterPart, slideLayoutPart) = CreateMinimalMasterAndLayout(presentationPart);
+
+        var slideIdList = new SlideIdList();
+        uint slideId = 256;
+
+        // Group A: slides 1 and 2 use imageA
+        // Group B: slides 3 and 4 use imageB
+        var images = new[] { imageA, imageA, imageB, imageB };
+        for (int i = 0; i < 4; i++)
+        {
+            var slidePart = presentationPart.AddNewPart<SlidePart>();
+            slidePart.AddPart(slideLayoutPart);
+
+            var imagePart = slidePart.AddImagePart(ImagePartType.Png);
+            using (var ms = new MemoryStream(images[i]))
+                imagePart.FeedData(ms);
+
+            var relId = slidePart.GetIdOfPart(imagePart);
+            slidePart.Slide = CreateSlideWithPicture(relId);
+
+            slideIdList.Append(new SlideId
+            {
+                Id = slideId++,
+                RelationshipId = presentationPart.GetIdOfPart(slidePart)
+            });
+        }
+
+        FinalizePresentationPart(presentationPart, slideIdList, slideMasterPart);
+        return path;
+    }
+
+    /// <summary>
+    /// Creates a PPTX where slide and layout both reference identical images.
+    /// </summary>
+    private string CreatePptxWithDuplicateImageOnLayout()
+    {
+        var path = System.IO.Path.Join(System.IO.Path.GetTempPath(), System.IO.Path.GetRandomFileName() + ".pptx");
+        TrackTempFile(path);
+
+        var imageBytes = CreatePngImage(0xCC);
+
+        using var doc = PresentationDocument.Create(path, PresentationDocumentType.Presentation);
+        var presentationPart = doc.AddPresentationPart();
+        var (slideMasterPart, slideLayoutPart) = CreateMinimalMasterAndLayout(presentationPart);
+
+        // Add image to layout
+        var layoutImagePart = slideLayoutPart.AddImagePart(ImagePartType.Png);
+        using (var ms = new MemoryStream(imageBytes))
+            layoutImagePart.FeedData(ms);
+
+        var layoutRelId = slideLayoutPart.GetIdOfPart(layoutImagePart);
+        AddPictureToShapeTree(slideLayoutPart.SlideLayout.CommonSlideData!.ShapeTree!, layoutRelId, 2);
+
+        // Add identical image to slide
+        var slidePart = presentationPart.AddNewPart<SlidePart>();
+        slidePart.AddPart(slideLayoutPart);
+
+        var slideImagePart = slidePart.AddImagePart(ImagePartType.Png);
+        using (var ms = new MemoryStream(imageBytes))
+            slideImagePart.FeedData(ms);
+
+        var slideRelId = slidePart.GetIdOfPart(slideImagePart);
+        slidePart.Slide = CreateSlideWithPicture(slideRelId);
+
+        var slideIdList = new SlideIdList(
+            new SlideId
+            {
+                Id = 256,
+                RelationshipId = presentationPart.GetIdOfPart(slidePart)
+            });
+
+        FinalizePresentationPart(presentationPart, slideIdList, slideMasterPart);
+        return path;
+    }
+
+    // ── Shared fixture helpers ──────────────────────────────
+
+    private static (SlideMasterPart Master, SlideLayoutPart Layout) CreateMinimalMasterAndLayout(
+        PresentationPart presentationPart)
+    {
+        var slideMasterPart = presentationPart.AddNewPart<SlideMasterPart>();
+        var slideLayoutPart = slideMasterPart.AddNewPart<SlideLayoutPart>();
+
+        slideLayoutPart.SlideLayout = new SlideLayout(
+            new CommonSlideData(
+                new ShapeTree(
+                    new P.NonVisualGroupShapeProperties(
+                        new P.NonVisualDrawingProperties { Id = 1, Name = string.Empty },
+                        new P.NonVisualGroupShapeDrawingProperties(),
+                        new ApplicationNonVisualDrawingProperties()),
+                    new GroupShapeProperties(new A.TransformGroup()))),
+            new ColorMapOverride(new A.MasterColorMapping()))
+        { Type = SlideLayoutValues.Title };
+        slideLayoutPart.SlideLayout.CommonSlideData!.Name = "Title Slide";
+        slideLayoutPart.AddPart(slideMasterPart);
+
+        slideMasterPart.SlideMaster = new SlideMaster(
+            new CommonSlideData(
+                new ShapeTree(
+                    new P.NonVisualGroupShapeProperties(
+                        new P.NonVisualDrawingProperties { Id = 1, Name = string.Empty },
+                        new P.NonVisualGroupShapeDrawingProperties(),
+                        new ApplicationNonVisualDrawingProperties()),
+                    new GroupShapeProperties(new A.TransformGroup()))),
+            new P.ColorMap
+            {
+                Background1 = A.ColorSchemeIndexValues.Light1,
+                Text1 = A.ColorSchemeIndexValues.Dark1,
+                Background2 = A.ColorSchemeIndexValues.Light2,
+                Text2 = A.ColorSchemeIndexValues.Dark2,
+                Accent1 = A.ColorSchemeIndexValues.Accent1,
+                Accent2 = A.ColorSchemeIndexValues.Accent2,
+                Accent3 = A.ColorSchemeIndexValues.Accent3,
+                Accent4 = A.ColorSchemeIndexValues.Accent4,
+                Accent5 = A.ColorSchemeIndexValues.Accent5,
+                Accent6 = A.ColorSchemeIndexValues.Accent6,
+                Hyperlink = A.ColorSchemeIndexValues.Hyperlink,
+                FollowedHyperlink = A.ColorSchemeIndexValues.FollowedHyperlink
+            },
+            new SlideLayoutIdList(
+                new SlideLayoutId
+                {
+                    Id = 2049,
+                    RelationshipId = slideMasterPart.GetIdOfPart(slideLayoutPart)
+                }));
+
+        return (slideMasterPart, slideLayoutPart);
+    }
+
+    private static void FinalizePresentationPart(PresentationPart presentationPart,
+        SlideIdList slideIdList, SlideMasterPart slideMasterPart)
+    {
+        var slideMasterIdList = new SlideMasterIdList(
+            new SlideMasterId
+            {
+                Id = 2147483648U,
+                RelationshipId = presentationPart.GetIdOfPart(slideMasterPart)
+            });
+
+        presentationPart.Presentation = new Presentation(
+            slideIdList,
+            new SlideSize { Cx = 9144000, Cy = 6858000, Type = SlideSizeValues.Screen4x3 },
+            new NotesSize { Cx = 6858000, Cy = 9144000 });
+
+        presentationPart.Presentation.InsertAt(slideMasterIdList, 0);
+        presentationPart.Presentation.Save();
+    }
+
+    private static Slide CreateSlideWithPicture(string imageRelId)
+    {
+        return new Slide(
+            new CommonSlideData(
+                new ShapeTree(
+                    new P.NonVisualGroupShapeProperties(
+                        new P.NonVisualDrawingProperties { Id = 1, Name = string.Empty },
+                        new P.NonVisualGroupShapeDrawingProperties(),
+                        new ApplicationNonVisualDrawingProperties()),
+                    new GroupShapeProperties(new A.TransformGroup()),
+                    new P.Picture(
+                        new P.NonVisualPictureProperties(
+                            new P.NonVisualDrawingProperties { Id = 2, Name = "Image 1" },
+                            new P.NonVisualPictureDrawingProperties(
+                                new A.PictureLocks { NoChangeAspect = true }),
+                            new ApplicationNonVisualDrawingProperties()),
+                        new P.BlipFill(
+                            new Blip { Embed = imageRelId },
+                            new Stretch(new FillRectangle())),
+                        new P.ShapeProperties(
+                            new A.Transform2D(
+                                new A.Offset { X = 0, Y = 0 },
+                                new A.Extents { Cx = 1000000, Cy = 1000000 }),
+                            new A.PresetGeometry(new A.AdjustValueList())
+                            { Preset = A.ShapeTypeValues.Rectangle })))));
+    }
+
+    private static void AddPictureToShapeTree(ShapeTree shapeTree, string imageRelId, uint shapeId)
+    {
+        shapeTree.Append(
+            new P.Picture(
+                new P.NonVisualPictureProperties(
+                    new P.NonVisualDrawingProperties { Id = shapeId, Name = $"Image {shapeId}" },
+                    new P.NonVisualPictureDrawingProperties(
+                        new A.PictureLocks { NoChangeAspect = true }),
+                    new ApplicationNonVisualDrawingProperties()),
+                new P.BlipFill(
+                    new Blip { Embed = imageRelId },
+                    new Stretch(new FillRectangle())),
+                new P.ShapeProperties(
+                    new A.Transform2D(
+                        new A.Offset { X = 0, Y = 0 },
+                        new A.Extents { Cx = 1000000, Cy = 1000000 }),
+                    new A.PresetGeometry(new A.AdjustValueList())
+                    { Preset = A.ShapeTypeValues.Rectangle })));
+    }
+
+    /// <summary>
+    /// Creates a minimal valid PNG image with a single pixel of the specified color value.
+    /// </summary>
+    private static byte[] CreatePngImage(byte colorValue)
+    {
+        // Minimal 1x1 PNG with varying pixel data to produce different hashes.
+        using var ms = new MemoryStream();
+        using var writer = new BinaryWriter(ms);
+
+        // PNG signature
+        writer.Write(new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A });
+
+        // IHDR chunk: 1x1, 8-bit RGB
+        WriteChunk(writer, "IHDR", new byte[]
+        {
+            0, 0, 0, 1, // width
+            0, 0, 0, 1, // height
+            8,           // bit depth
+            2,           // color type (RGB)
+            0, 0, 0      // compression, filter, interlace
+        });
+
+        // IDAT chunk: deflated scanline (filter byte + 3 RGB bytes)
+        var rawScanline = new byte[] { 0, colorValue, colorValue, colorValue };
+        var deflated = DeflateCompress(rawScanline);
+        WriteChunk(writer, "IDAT", deflated);
+
+        // IEND chunk
+        WriteChunk(writer, "IEND", []);
+
+        return ms.ToArray();
+    }
+
+    private static void WriteChunk(BinaryWriter writer, string type, byte[] data)
+    {
+        var typeBytes = System.Text.Encoding.ASCII.GetBytes(type);
+        writer.Write(ToBigEndian(data.Length));
+        writer.Write(typeBytes);
+        writer.Write(data);
+
+        // CRC32 over type + data
+        var crcData = new byte[typeBytes.Length + data.Length];
+        typeBytes.CopyTo(crcData, 0);
+        data.CopyTo(crcData, typeBytes.Length);
+        writer.Write(ToBigEndian((int)Crc32(crcData)));
+    }
+
+    private static byte[] ToBigEndian(int value) =>
+        [(byte)(value >> 24), (byte)(value >> 16), (byte)(value >> 8), (byte)value];
+
+    private static byte[] DeflateCompress(byte[] data)
+    {
+        using var ms = new MemoryStream();
+        // zlib header
+        ms.WriteByte(0x78);
+        ms.WriteByte(0x01);
+        using (var deflate = new System.IO.Compression.DeflateStream(ms,
+            System.IO.Compression.CompressionLevel.NoCompression, leaveOpen: true))
+        {
+            deflate.Write(data, 0, data.Length);
+        }
+        // Adler32 checksum
+        var adler = Adler32(data);
+        ms.Write(ToBigEndian((int)adler));
+        return ms.ToArray();
+    }
+
+    private static uint Adler32(byte[] data)
+    {
+        uint a = 1, b = 0;
+        foreach (var d in data)
+        {
+            a = (a + d) % 65521;
+            b = (b + a) % 65521;
+        }
+        return (b << 16) | a;
+    }
+
+    private static uint Crc32(byte[] data)
+    {
+        uint crc = 0xFFFFFFFF;
+        foreach (var b in data)
+        {
+            crc ^= b;
+            for (int i = 0; i < 8; i++)
+                crc = (crc >> 1) ^ (0xEDB88320 & ~((crc & 1) - 1));
+        }
+        return crc ^ 0xFFFFFFFF;
+    }
+}


### PR DESCRIPTION
Implements #84: Deduplicate identical media in PPTX files.

Finds media parts with identical content (SHA256 hash match), redirects all references to a single canonical copy, and removes orphaned duplicates.

- Handles images across slides, layouts, and masters
- Updates all Blip.Embed relationships to point to canonical part
- Validates package integrity before and after
- Returns structured JSON with dedup statistics and space saved
- 10 new tests (542/542 passing)

Closes #84