### PR TITLE
feat: CLI analyze and export commands (#99, #102)

### DIFF
--- a/src/PptxMcp/Commands/AnalyzeCommand.cs
+++ b/src/PptxMcp/Commands/AnalyzeCommand.cs
@@ -1,0 +1,130 @@
+using System.CommandLine;
+using PptxMcp.Services;
+
+namespace PptxMcp.Commands;
+
+/// <summary>CLI command group for presentation analysis.</summary>
+public static class AnalyzeCommand
+{
+    public static Command Create(PresentationService service)
+    {
+        var command = new Command("analyze") { Description = "Analyze presentation structure and content" };
+        command.Add(CreateFileSizeCommand(service));
+        command.Add(CreateTalkingPointsCommand(service));
+        return command;
+    }
+
+    private static Command CreateFileSizeCommand(PresentationService service)
+    {
+        var fileArg = new Argument<string>("file") { Description = "Path to the .pptx file" };
+        var jsonOption = new Option<bool>("--json") { Description = "Output as JSON" };
+
+        var cmd = new Command("file-size") { Description = "Analyze file size breakdown by category" };
+        cmd.Add(fileArg);
+        cmd.Add(jsonOption);
+
+        cmd.SetAction((Func<ParseResult, int>)(parseResult =>
+        {
+            var filePath = parseResult.GetValue(fileArg)!;
+            var asJson = parseResult.GetValue(jsonOption);
+
+            if (!File.Exists(filePath))
+            {
+                Console.Error.WriteLine($"Error: File not found: {filePath}");
+                return 1;
+            }
+
+            var result = service.AnalyzeFileSize(filePath);
+
+            if (asJson)
+            {
+                Console.WriteLine(JsonSerializer.Serialize(result, JsonOptions));
+                return 0;
+            }
+
+            Console.WriteLine($"File: {result.FilePath}");
+            Console.WriteLine($"Total file size: {FormatBytes(result.TotalFileSize)}");
+            Console.WriteLine($"Total part size: {FormatBytes(result.TotalPartSize)}");
+            Console.WriteLine();
+
+            foreach (var category in result.Categories)
+            {
+                if (category.PartCount == 0)
+                    continue;
+
+                Console.WriteLine($"  {category.Name} ({category.PartCount} parts, {FormatBytes(category.TotalSize)})");
+                foreach (var part in category.Parts)
+                {
+                    Console.WriteLine($"    {part.Path}  {FormatBytes(part.Size)}  [{part.ContentType}]");
+                }
+            }
+
+            return 0;
+        }));
+
+        return cmd;
+    }
+
+    private static Command CreateTalkingPointsCommand(PresentationService service)
+    {
+        var fileArg = new Argument<string>("file") { Description = "Path to the .pptx file" };
+        var topOption = new Option<int>("--top") { Description = "Number of talking points per slide", DefaultValueFactory = _ => 5 };
+        var jsonOption = new Option<bool>("--json") { Description = "Output as JSON" };
+
+        var cmd = new Command("talking-points") { Description = "Extract key talking points from slides" };
+        cmd.Add(fileArg);
+        cmd.Add(topOption);
+        cmd.Add(jsonOption);
+
+        cmd.SetAction((Func<ParseResult, int>)(parseResult =>
+        {
+            var filePath = parseResult.GetValue(fileArg)!;
+            var topN = parseResult.GetValue(topOption);
+            var asJson = parseResult.GetValue(jsonOption);
+
+            if (!File.Exists(filePath))
+            {
+                Console.Error.WriteLine($"Error: File not found: {filePath}");
+                return 1;
+            }
+
+            var result = service.ExtractTalkingPoints(filePath, topN);
+
+            if (asJson)
+            {
+                Console.WriteLine(JsonSerializer.Serialize(result, JsonOptions));
+                return 0;
+            }
+
+            foreach (var slide in result)
+            {
+                var title = slide.Title ?? "(untitled)";
+                Console.WriteLine($"Slide {slide.SlideIndex + 1}: {title}");
+                foreach (var point in slide.Points)
+                {
+                    Console.WriteLine($"  • {point}");
+                }
+                if (slide.Points.Count == 0)
+                    Console.WriteLine("  (no talking points)");
+                Console.WriteLine();
+            }
+
+            return 0;
+        }));
+
+        return cmd;
+    }
+
+    private static string FormatBytes(long bytes)
+    {
+        return bytes switch
+        {
+            >= 1_073_741_824 => $"{bytes / 1_073_741_824.0:F1} GB",
+            >= 1_048_576 => $"{bytes / 1_048_576.0:F1} MB",
+            >= 1_024 => $"{bytes / 1_024.0:F1} KB",
+            _ => $"{bytes} B"
+        };
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+}

--- a/src/PptxMcp/Commands/ExportCommand.cs
+++ b/src/PptxMcp/Commands/ExportCommand.cs
@@ -1,0 +1,65 @@
+using System.CommandLine;
+using PptxMcp.Services;
+
+namespace PptxMcp.Commands;
+
+/// <summary>CLI command group for presentation export.</summary>
+public static class ExportCommand
+{
+    public static Command Create(PresentationService service)
+    {
+        var command = new Command("export") { Description = "Export presentation content" };
+        command.Add(CreateMarkdownCommand(service));
+        return command;
+    }
+
+    private static Command CreateMarkdownCommand(PresentationService service)
+    {
+        var fileArg = new Argument<string>("file") { Description = "Path to the .pptx file" };
+        var outputArg = new Argument<string?>("output") { Description = "Output file path (defaults to stdout)", DefaultValueFactory = _ => null };
+        var jsonOption = new Option<bool>("--json") { Description = "Output as JSON" };
+
+        var cmd = new Command("markdown") { Description = "Export presentation as Markdown" };
+        cmd.Add(fileArg);
+        cmd.Add(outputArg);
+        cmd.Add(jsonOption);
+
+        cmd.SetAction((Func<ParseResult, int>)(parseResult =>
+        {
+            var filePath = parseResult.GetValue(fileArg)!;
+            var outputPath = parseResult.GetValue(outputArg);
+            var asJson = parseResult.GetValue(jsonOption);
+
+            if (!File.Exists(filePath))
+            {
+                Console.Error.WriteLine($"Error: File not found: {filePath}");
+                return 1;
+            }
+
+            var result = service.ExportMarkdown(filePath, outputPath);
+
+            if (asJson)
+            {
+                Console.WriteLine(JsonSerializer.Serialize(result, JsonOptions));
+                return 0;
+            }
+
+            if (outputPath is not null)
+            {
+                Console.WriteLine($"Exported {result.SlideCount} slides to {result.OutputPath}");
+                if (result.ImageCount > 0)
+                    Console.WriteLine($"Extracted {result.ImageCount} images");
+            }
+            else
+            {
+                Console.Write(result.Markdown);
+            }
+
+            return 0;
+        }));
+
+        return cmd;
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+}

--- a/src/PptxMcp/Program.cs
+++ b/src/PptxMcp/Program.cs
@@ -2,6 +2,7 @@ using System.CommandLine;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using PptxMcp.Commands;
 using PptxMcp.Completions;
 using PptxMcp.Prompts;
 using PptxMcp.Resources;
@@ -71,14 +72,22 @@ static async Task RunMcpServerAsync(string[] args)
 
 static async Task<int> RunCliAsync(string[] args)
 {
+    var services = new ServiceCollection();
+    services.AddSingleton<PresentationService>();
+    var sp = services.BuildServiceProvider();
+    var service = sp.GetRequiredService<PresentationService>();
+
     var rootCommand = new RootCommand("PowerPoint MCP - Analyze, optimize, and edit PowerPoint files");
 
+    // Real commands
+    rootCommand.Add(AnalyzeCommand.Create(service));
+    rootCommand.Add(ExportCommand.Create(service));
+
+    // Stubs for unimplemented commands
     (string name, string desc, int issue)[] stubs =
     [
-        ("analyze", "Analyze presentation structure and content", 99),
         ("optimize", "Optimize presentation file size", 100),
         ("inspect", "Inspect slide details and metadata", 101),
-        ("export", "Export presentation content", 102),
         ("edit", "Edit presentation content", 103),
         ("media", "Manage media assets", 104),
         ("slides", "Manage slides", 105),


### PR DESCRIPTION
Implements analyze (file-size, talking-points) and export (markdown) CLI command groups.

## Changes

- **AnalyzeCommand.cs** — \nalyze file-size <file>\ and \nalyze talking-points <file> [--top N]\ subcommands
- **ExportCommand.cs** — \xport markdown <file> [output]\ subcommand  
- **Program.cs** — DI wiring, real commands replace stubs for analyze/export

## Features

- Human-readable text output by default
- \--json\ flag on each subcommand for structured JSON output
- Proper exit code 1 on file-not-found errors
- Remaining 5 commands stay as stubs

## Testing

- 575/575 existing tests pass
- Build succeeds with no new warnings
- Smoke tested: analyze --help, export --help, error handling

Closes #99
Closes #102