### PR TITLE
feat: CLI inspect, media, and slides commands (#101, #104)

### DIFF
--- a/src/PptxMcp/Commands/InspectCommand.cs
+++ b/src/PptxMcp/Commands/InspectCommand.cs
@@ -1,0 +1,193 @@
+using System.CommandLine;
+using PptxMcp.Services;
+
+namespace PptxMcp.Commands;
+
+/// <summary>CLI command group for inspecting slide details and metadata.</summary>
+public static class InspectCommand
+{
+    public static Command Create(PresentationService service)
+    {
+        var command = new Command("inspect") { Description = "Inspect slide details and metadata" };
+        command.Add(CreateSlidesCommand(service));
+        command.Add(CreateContentCommand(service));
+        command.Add(CreateXmlCommand(service));
+        command.Add(CreateLayoutsCommand(service));
+        return command;
+    }
+
+    private static Command CreateSlidesCommand(PresentationService service)
+    {
+        var fileArg = new Argument<string>("file") { Description = "Path to the .pptx file" };
+        var jsonOption = new Option<bool>("--json") { Description = "Output as JSON" };
+
+        var cmd = new Command("slides") { Description = "List all slides in the presentation" };
+        cmd.Add(fileArg);
+        cmd.Add(jsonOption);
+
+        cmd.SetAction(parseResult =>
+        {
+            var filePath = parseResult.GetValue(fileArg)!;
+            var asJson = parseResult.GetValue(jsonOption);
+
+            if (!File.Exists(filePath))
+            {
+                Console.Error.WriteLine($"Error: File not found: {filePath}");
+                Environment.ExitCode = 1;
+                return;
+            }
+
+            var slides = service.GetSlides(filePath);
+
+            if (asJson)
+            {
+                Console.WriteLine(JsonSerializer.Serialize(slides, JsonOptions));
+                return;
+            }
+
+            Console.WriteLine($"Slides ({slides.Count}):");
+            Console.WriteLine();
+            foreach (var slide in slides)
+            {
+                var title = slide.Title ?? "(untitled)";
+                Console.WriteLine($"  Slide {slide.Index + 1}: {title}");
+                Console.WriteLine($"    Placeholders: {slide.PlaceholderCount}");
+                if (slide.Notes is not null)
+                    Console.WriteLine($"    Notes: {Truncate(slide.Notes, 80)}");
+            }
+        });
+
+        return cmd;
+    }
+
+    private static Command CreateContentCommand(PresentationService service)
+    {
+        var fileArg = new Argument<string>("file") { Description = "Path to the .pptx file" };
+        var slideOption = new Option<int>("--slide") { Description = "Slide number (1-based)", Required = true };
+        var jsonOption = new Option<bool>("--json") { Description = "Output as JSON" };
+
+        var cmd = new Command("content") { Description = "Get detailed shape content for a slide" };
+        cmd.Add(fileArg);
+        cmd.Add(slideOption);
+        cmd.Add(jsonOption);
+
+        cmd.SetAction(parseResult =>
+        {
+            var filePath = parseResult.GetValue(fileArg)!;
+            var slideNumber = parseResult.GetValue(slideOption);
+            var asJson = parseResult.GetValue(jsonOption);
+
+            if (!File.Exists(filePath))
+            {
+                Console.Error.WriteLine($"Error: File not found: {filePath}");
+                Environment.ExitCode = 1;
+                return;
+            }
+
+            // Service uses 0-based slideIndex
+            var content = service.GetSlideContent(filePath, slideNumber - 1);
+
+            if (asJson)
+            {
+                Console.WriteLine(JsonSerializer.Serialize(content, JsonOptions));
+                return;
+            }
+
+            Console.WriteLine($"Slide {slideNumber} ({content.Shapes.Count} shapes)");
+            Console.WriteLine($"  Size: {content.SlideWidthEmu} x {content.SlideHeightEmu} EMU");
+            Console.WriteLine();
+
+            foreach (var shape in content.Shapes)
+            {
+                Console.WriteLine($"  [{shape.ShapeType}] {shape.Name}");
+                if (shape.IsPlaceholder)
+                    Console.WriteLine($"    Placeholder: {shape.PlaceholderType ?? "unknown"} (index {shape.PlaceholderIndex})");
+                if (shape.X is not null)
+                    Console.WriteLine($"    Position: ({shape.X}, {shape.Y}) Size: ({shape.Width}, {shape.Height})");
+                if (shape.Text is not null)
+                    Console.WriteLine($"    Text: {Truncate(shape.Text, 120)}");
+                if (shape.TableRows is not null)
+                    Console.WriteLine($"    Table: {shape.TableRows.Count} rows");
+            }
+        });
+
+        return cmd;
+    }
+
+    private static Command CreateXmlCommand(PresentationService service)
+    {
+        var fileArg = new Argument<string>("file") { Description = "Path to the .pptx file" };
+        var slideOption = new Option<int>("--slide") { Description = "Slide number (1-based)", Required = true };
+
+        var cmd = new Command("xml") { Description = "Get raw slide XML" };
+        cmd.Add(fileArg);
+        cmd.Add(slideOption);
+
+        cmd.SetAction(parseResult =>
+        {
+            var filePath = parseResult.GetValue(fileArg)!;
+            var slideNumber = parseResult.GetValue(slideOption);
+
+            if (!File.Exists(filePath))
+            {
+                Console.Error.WriteLine($"Error: File not found: {filePath}");
+                Environment.ExitCode = 1;
+                return;
+            }
+
+            // Service uses 0-based slideIndex
+            var xml = service.GetSlideXml(filePath, slideNumber - 1);
+            Console.WriteLine(xml);
+        });
+
+        return cmd;
+    }
+
+    private static Command CreateLayoutsCommand(PresentationService service)
+    {
+        var fileArg = new Argument<string>("file") { Description = "Path to the .pptx file" };
+        var jsonOption = new Option<bool>("--json") { Description = "Output as JSON" };
+
+        var cmd = new Command("layouts") { Description = "List all available slide layouts" };
+        cmd.Add(fileArg);
+        cmd.Add(jsonOption);
+
+        cmd.SetAction(parseResult =>
+        {
+            var filePath = parseResult.GetValue(fileArg)!;
+            var asJson = parseResult.GetValue(jsonOption);
+
+            if (!File.Exists(filePath))
+            {
+                Console.Error.WriteLine($"Error: File not found: {filePath}");
+                Environment.ExitCode = 1;
+                return;
+            }
+
+            var layouts = service.GetLayouts(filePath);
+
+            if (asJson)
+            {
+                Console.WriteLine(JsonSerializer.Serialize(layouts, JsonOptions));
+                return;
+            }
+
+            Console.WriteLine($"Layouts ({layouts.Count}):");
+            Console.WriteLine();
+            foreach (var layout in layouts)
+            {
+                Console.WriteLine($"  {layout.Index + 1}. {layout.Name}");
+            }
+        });
+
+        return cmd;
+    }
+
+    private static string Truncate(string text, int maxLength)
+    {
+        var singleLine = text.ReplaceLineEndings(" ");
+        return singleLine.Length <= maxLength ? singleLine : string.Concat(singleLine.AsSpan(0, maxLength - 3), "...");
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+}

--- a/src/PptxMcp/Commands/MediaCommand.cs
+++ b/src/PptxMcp/Commands/MediaCommand.cs
@@ -1,0 +1,197 @@
+using System.CommandLine;
+using PptxMcp.Services;
+
+namespace PptxMcp.Commands;
+
+/// <summary>CLI command group for managing media assets.</summary>
+public static class MediaCommand
+{
+    public static Command Create(PresentationService service)
+    {
+        var command = new Command("media") { Description = "Manage media assets" };
+        command.Add(CreateAnalyzeCommand(service));
+        command.Add(CreateDeduplicateCommand(service));
+        command.Add(CreateAnalyzeVideoCommand(service));
+        return command;
+    }
+
+    private static Command CreateAnalyzeCommand(PresentationService service)
+    {
+        var fileArg = new Argument<string>("file") { Description = "Path to the .pptx file" };
+        var jsonOption = new Option<bool>("--json") { Description = "Output as JSON" };
+
+        var cmd = new Command("analyze") { Description = "Analyze media inventory in the presentation" };
+        cmd.Add(fileArg);
+        cmd.Add(jsonOption);
+
+        cmd.SetAction(parseResult =>
+        {
+            var filePath = parseResult.GetValue(fileArg)!;
+            var asJson = parseResult.GetValue(jsonOption);
+
+            if (!File.Exists(filePath))
+            {
+                Console.Error.WriteLine($"Error: File not found: {filePath}");
+                Environment.ExitCode = 1;
+                return;
+            }
+
+            var result = service.AnalyzeMedia(filePath);
+
+            if (asJson)
+            {
+                Console.WriteLine(JsonSerializer.Serialize(result, JsonOptions));
+                return;
+            }
+
+            Console.WriteLine($"Media Analysis: {filePath}");
+            Console.WriteLine($"  Total media: {result.TotalMediaCount} parts, {FormatBytes(result.TotalMediaSize)}");
+            Console.WriteLine($"  Duplicate groups: {result.DuplicateGroupCount} (potential savings: {FormatBytes(result.DuplicateSavingsBytes)})");
+            Console.WriteLine();
+
+            if (result.MediaParts.Length > 0)
+            {
+                Console.WriteLine("Media parts:");
+                foreach (var part in result.MediaParts)
+                {
+                    var slides = part.ReferencedBySlides.Length > 0
+                        ? $"slides {string.Join(", ", part.ReferencedBySlides)}"
+                        : "no slide references";
+                    Console.WriteLine($"  {part.Path}  {FormatBytes(part.SizeBytes)}  [{part.ContentType}]  ({slides})");
+                }
+            }
+
+            if (result.DuplicateGroups.Length > 0)
+            {
+                Console.WriteLine();
+                Console.WriteLine("Duplicate groups:");
+                foreach (var group in result.DuplicateGroups)
+                {
+                    Console.WriteLine($"  [{group.ContentType}] {FormatBytes(group.SizeBytes)} x {group.Parts.Length} copies");
+                    foreach (var part in group.Parts)
+                        Console.WriteLine($"    {part}");
+                }
+            }
+        });
+
+        return cmd;
+    }
+
+    private static Command CreateDeduplicateCommand(PresentationService service)
+    {
+        var fileArg = new Argument<string>("file") { Description = "Path to the .pptx file" };
+        var jsonOption = new Option<bool>("--json") { Description = "Output as JSON" };
+
+        var cmd = new Command("deduplicate") { Description = "Remove duplicate media from the presentation" };
+        cmd.Add(fileArg);
+        cmd.Add(jsonOption);
+
+        cmd.SetAction(parseResult =>
+        {
+            var filePath = parseResult.GetValue(fileArg)!;
+            var asJson = parseResult.GetValue(jsonOption);
+
+            if (!File.Exists(filePath))
+            {
+                Console.Error.WriteLine($"Error: File not found: {filePath}");
+                Environment.ExitCode = 1;
+                return;
+            }
+
+            var result = service.DeduplicateMedia(filePath);
+
+            if (asJson)
+            {
+                Console.WriteLine(JsonSerializer.Serialize(result, JsonOptions));
+                return;
+            }
+
+            Console.WriteLine(result.Message);
+            if (result.Success && result.PartsRemoved > 0)
+            {
+                Console.WriteLine($"  Groups found: {result.DuplicateGroupsFound}");
+                Console.WriteLine($"  Parts removed: {result.PartsRemoved}");
+                Console.WriteLine($"  Bytes saved: {FormatBytes(result.BytesSaved)}");
+                Console.WriteLine($"  Validation: {(result.Validation.IsValid ? "passed" : "failed")}");
+            }
+        });
+
+        return cmd;
+    }
+
+    private static Command CreateAnalyzeVideoCommand(PresentationService service)
+    {
+        var fileArg = new Argument<string>("file") { Description = "Path to the .pptx file" };
+        var jsonOption = new Option<bool>("--json") { Description = "Output as JSON" };
+
+        var cmd = new Command("analyze-video") { Description = "Analyze video and audio metadata" };
+        cmd.Add(fileArg);
+        cmd.Add(jsonOption);
+
+        cmd.SetAction(parseResult =>
+        {
+            var filePath = parseResult.GetValue(fileArg)!;
+            var asJson = parseResult.GetValue(jsonOption);
+
+            if (!File.Exists(filePath))
+            {
+                Console.Error.WriteLine($"Error: File not found: {filePath}");
+                Environment.ExitCode = 1;
+                return;
+            }
+
+            var result = service.AnalyzeVideoMetadata(filePath);
+
+            if (asJson)
+            {
+                Console.WriteLine(JsonSerializer.Serialize(result, JsonOptions));
+                return;
+            }
+
+            Console.WriteLine($"Video/Audio Analysis: {filePath}");
+            Console.WriteLine($"  Parts found: {result.VideoPartsFound}");
+            Console.WriteLine($"  Total tracks: {result.TotalTracks}");
+            Console.WriteLine();
+
+            foreach (var part in result.Parts)
+            {
+                Console.WriteLine($"  {part.PartUri}  [{part.ContentType}]  {FormatBytes(part.FileSizeBytes)}");
+                if (part.Error is not null)
+                {
+                    Console.WriteLine($"    Error: {part.Error}");
+                    continue;
+                }
+                foreach (var track in part.Tracks)
+                {
+                    var details = track.TrackType switch
+                    {
+                        "Video" => $"{track.Codec} {track.Width}x{track.Height}" +
+                                   (track.DurationSeconds.HasValue ? $" {track.DurationSeconds:F1}s" : "") +
+                                   (track.Bitrate.HasValue ? $" {FormatBytes(track.Bitrate.Value)}/s" : ""),
+                        "Audio" => $"{track.Codec}" +
+                                   (track.ChannelCount.HasValue ? $" {track.ChannelCount}ch" : "") +
+                                   (track.SampleRate.HasValue ? $" {track.SampleRate}Hz" : "") +
+                                   (track.DurationSeconds.HasValue ? $" {track.DurationSeconds:F1}s" : ""),
+                        _ => track.Codec
+                    };
+                    Console.WriteLine($"    [{track.TrackType}] {details}");
+                }
+            }
+        });
+
+        return cmd;
+    }
+
+    private static string FormatBytes(long bytes)
+    {
+        return bytes switch
+        {
+            >= 1_073_741_824 => $"{bytes / 1_073_741_824.0:F1} GB",
+            >= 1_048_576 => $"{bytes / 1_048_576.0:F1} MB",
+            >= 1_024 => $"{bytes / 1_024.0:F1} KB",
+            _ => $"{bytes} B"
+        };
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+}

--- a/src/PptxMcp/Commands/SlidesCommand.cs
+++ b/src/PptxMcp/Commands/SlidesCommand.cs
@@ -1,0 +1,192 @@
+using System.CommandLine;
+using PptxMcp.Services;
+
+namespace PptxMcp.Commands;
+
+/// <summary>CLI command group for managing slides.</summary>
+public static class SlidesCommand
+{
+    public static Command Create(PresentationService service)
+    {
+        var command = new Command("slides") { Description = "Manage slides" };
+        command.Add(CreateAddCommand(service));
+        command.Add(CreateDeleteCommand(service));
+        command.Add(CreateReorderCommand(service));
+        command.Add(CreateDuplicateCommand(service));
+        return command;
+    }
+
+    private static Command CreateAddCommand(PresentationService service)
+    {
+        var fileArg = new Argument<string>("file") { Description = "Path to the .pptx file" };
+        var layoutOption = new Option<string?>("--layout") { Description = "Layout name to use for the new slide", DefaultValueFactory = _ => null };
+        var jsonOption = new Option<bool>("--json") { Description = "Output as JSON" };
+
+        var cmd = new Command("add") { Description = "Add a new slide to the presentation" };
+        cmd.Add(fileArg);
+        cmd.Add(layoutOption);
+        cmd.Add(jsonOption);
+
+        cmd.SetAction(parseResult =>
+        {
+            var filePath = parseResult.GetValue(fileArg)!;
+            var layoutName = parseResult.GetValue(layoutOption);
+            var asJson = parseResult.GetValue(jsonOption);
+
+            if (!File.Exists(filePath))
+            {
+                Console.Error.WriteLine($"Error: File not found: {filePath}");
+                Environment.ExitCode = 1;
+                return;
+            }
+
+            if (layoutName is not null)
+            {
+                var result = service.AddSlideFromLayout(filePath, layoutName);
+                if (asJson)
+                {
+                    Console.WriteLine(JsonSerializer.Serialize(result, JsonOptions));
+                    return;
+                }
+                Console.WriteLine(result.Message);
+            }
+            else
+            {
+                var slideNumber = service.AddSlide(filePath, null);
+                if (asJson)
+                {
+                    Console.WriteLine(JsonSerializer.Serialize(new { SlideNumber = slideNumber }, JsonOptions));
+                    return;
+                }
+                Console.WriteLine($"Added slide {slideNumber}");
+            }
+        });
+
+        return cmd;
+    }
+
+    private static Command CreateDeleteCommand(PresentationService service)
+    {
+        var fileArg = new Argument<string>("file") { Description = "Path to the .pptx file" };
+        var slideOption = new Option<int>("--slide") { Description = "Slide number to delete (1-based)", Required = true };
+
+        var cmd = new Command("delete") { Description = "Delete a slide from the presentation" };
+        cmd.Add(fileArg);
+        cmd.Add(slideOption);
+
+        cmd.SetAction(parseResult =>
+        {
+            var filePath = parseResult.GetValue(fileArg)!;
+            var slideNumber = parseResult.GetValue(slideOption);
+
+            if (!File.Exists(filePath))
+            {
+                Console.Error.WriteLine($"Error: File not found: {filePath}");
+                Environment.ExitCode = 1;
+                return;
+            }
+
+            service.DeleteSlide(filePath, slideNumber);
+            Console.WriteLine($"Deleted slide {slideNumber}");
+        });
+
+        return cmd;
+    }
+
+    private static Command CreateReorderCommand(PresentationService service)
+    {
+        var fileArg = new Argument<string>("file") { Description = "Path to the .pptx file" };
+        var orderOption = new Option<string>("--order") { Description = "New slide order as comma-separated numbers (e.g. 3,1,2)", Required = true };
+        var jsonOption = new Option<bool>("--json") { Description = "Output as JSON" };
+
+        var cmd = new Command("reorder") { Description = "Reorder slides in the presentation" };
+        cmd.Add(fileArg);
+        cmd.Add(orderOption);
+        cmd.Add(jsonOption);
+
+        cmd.SetAction(parseResult =>
+        {
+            var filePath = parseResult.GetValue(fileArg)!;
+            var orderStr = parseResult.GetValue(orderOption)!;
+            var asJson = parseResult.GetValue(jsonOption);
+
+            if (!File.Exists(filePath))
+            {
+                Console.Error.WriteLine($"Error: File not found: {filePath}");
+                Environment.ExitCode = 1;
+                return;
+            }
+
+            int[] newOrder;
+            try
+            {
+                newOrder = orderStr.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                    .Select(int.Parse)
+                    .ToArray();
+            }
+            catch (FormatException)
+            {
+                Console.Error.WriteLine("Error: Invalid order format. Use comma-separated numbers (e.g. 3,1,2)");
+                Environment.ExitCode = 1;
+                return;
+            }
+
+            service.ReorderSlides(filePath, newOrder);
+
+            if (asJson)
+            {
+                Console.WriteLine(JsonSerializer.Serialize(new { Success = true, NewOrder = newOrder }, JsonOptions));
+                return;
+            }
+
+            Console.WriteLine($"Reordered slides: {string.Join(", ", newOrder)}");
+        });
+
+        return cmd;
+    }
+
+    private static Command CreateDuplicateCommand(PresentationService service)
+    {
+        var fileArg = new Argument<string>("file") { Description = "Path to the .pptx file" };
+        var slideOption = new Option<int>("--slide") { Description = "Slide number to duplicate (1-based)", Required = true };
+        var jsonOption = new Option<bool>("--json") { Description = "Output as JSON" };
+
+        var cmd = new Command("duplicate") { Description = "Duplicate a slide" };
+        cmd.Add(fileArg);
+        cmd.Add(slideOption);
+        cmd.Add(jsonOption);
+
+        cmd.SetAction(parseResult =>
+        {
+            var filePath = parseResult.GetValue(fileArg)!;
+            var slideNumber = parseResult.GetValue(slideOption);
+            var asJson = parseResult.GetValue(jsonOption);
+
+            if (!File.Exists(filePath))
+            {
+                Console.Error.WriteLine($"Error: File not found: {filePath}");
+                Environment.ExitCode = 1;
+                return;
+            }
+
+            var result = service.DuplicateSlide(filePath, slideNumber);
+
+            if (asJson)
+            {
+                Console.WriteLine(JsonSerializer.Serialize(result, JsonOptions));
+                return;
+            }
+
+            Console.WriteLine(result.Message);
+            if (result.Success)
+            {
+                Console.WriteLine($"  New slide number: {result.NewSlideNumber}");
+                Console.WriteLine($"  Shapes copied: {result.ShapesCopied}");
+            }
+        });
+
+        return cmd;
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+}

--- a/src/PptxMcp/Program.cs
+++ b/src/PptxMcp/Program.cs
@@ -82,15 +82,15 @@ static async Task<int> RunCliAsync(string[] args)
     // Real commands
     rootCommand.Add(AnalyzeCommand.Create(service));
     rootCommand.Add(ExportCommand.Create(service));
+    rootCommand.Add(InspectCommand.Create(service));
+    rootCommand.Add(MediaCommand.Create(service));
+    rootCommand.Add(SlidesCommand.Create(service));
 
     // Stubs for unimplemented commands
     (string name, string desc, int issue)[] stubs =
     [
         ("optimize", "Optimize presentation file size", 100),
-        ("inspect", "Inspect slide details and metadata", 101),
         ("edit", "Edit presentation content", 103),
-        ("media", "Manage media assets", 104),
-        ("slides", "Manage slides", 105),
     ];
 
     foreach (var (name, desc, issue) in stubs)


### PR DESCRIPTION
Implements inspect (slides, content, xml, layouts), media (analyze, deduplicate, analyze-video), and slides (add, delete, reorder, duplicate) CLI command groups.

All read-only subcommands support \--json\ for JSON output. Program.cs wired with DI/ServiceCollection and PresentationService injection.

**New files:**
- \src/PptxMcp/Commands/InspectCommand.cs\ — 4 subcommands
- \src/PptxMcp/Commands/MediaCommand.cs\ — 3 subcommands
- \src/PptxMcp/Commands/SlidesCommand.cs\ — 4 subcommands

**Modified:**
- \src/PptxMcp/Program.cs\ — DI setup, real command wiring, reduced stubs

✅ 575/575 tests pass, 0 new errors, 0 new warnings.

Closes #101
Closes #104