### PR TITLE
Add ValidationHelpers and improve error messages across service layer

### DIFF
--- a/.squad/agents/cheritto/history.md
+++ b/.squad/agents/cheritto/history.md
@@ -291,3 +291,17 @@
 - **Build:** 0 errors; pre-existing warnings only
 - **PR:** #153 on branch squad/130-extend-batch-operations
 
+
+### Validation helpers (#140, 2026-03-26)
+- Created `src/PptxTools/Services/ValidationHelpers.cs` as centralized validation utility with methods for slide numbers, slide indices, EMU values, file paths, image paths, color formats, and shape/table not-found messages
+- Applied `ValidateSlideNumber` to `InsertTable`, `UpdateTable`, `DeleteSlide`, and `FindTableOnSlide` (TableStructure) — all 1-based slide number entry points now validate consistently
+- Applied `ValidateSlideIndex` in `GetSlidePart` — all 0-based slide index entry points now get actionable messages with valid range
+- Applied `ValidateImagePath` and `ValidateEmuValue` in `InsertImage` and `InsertTable` — catches bad image formats and negative EMU values early
+- Enhanced `UpdateSlideData` slide range message to include valid range (`Valid range: 1-N`)
+- Enhanced `ReplaceImage` slide range message with same pattern
+- Enhanced `UpdateTable` skip message to include table dimensions when cells are out of range
+- Enhanced `FindTableOnSlide` (TableStructure) table-not-found message to include table count
+- Enhanced `DeleteTableRow`/`DeleteTableColumn` range messages to include valid range
+- All error messages preserved backward-compatible keywords (`out of range`, `not found`, `must be 1 or greater`) that existing tests assert on
+- No method signatures or return types changed; no tool layer files touched
+- 1227 tests pass, 0 failures

--- a/.squad/agents/shiherlis/history.md
+++ b/.squad/agents/shiherlis/history.md
@@ -250,3 +250,24 @@
   - Table cell coordinates are 0-based; shape lookup is case-insensitive across Shape, Picture, and GraphicFrame elements
   - `UpdateShapeProperties` requires at least one property — returns error if all X/Y/W/H/Rotation are null
   - `ReplaceImage` reuses `ResolvePictureTarget` and `GetPictureTargets` from image replace service
+
+### Issue #140 ValidationHelpers Test Suite (2026-03-26)
+- **Scope:** 95 new tests in `tests/PptxTools.Tests/Services/ValidationHelperTests.cs` for centralized validation
+- **Written in parallel** with Cheritto's `ValidationHelpers.cs` implementation — polled for file existence before starting
+- **Coverage:** 1227/1227 tests passing, zero regressions
+- **Methods tested (all public static on ValidationHelpers):**
+  - `ValidateSlideNumber`: range validation (1-based), zero-total-slides → InvalidOperationException, context parameter appended
+  - `ValidateSlideIndex`: range validation (0-based), same zero-total pattern
+  - `ValidateEmuValue`: negative → ArgumentOutOfRangeException with EMU hint (914400), zero/positive accepted
+  - `ValidateFilePath`: null/empty, file not found, non-.pptx extension, valid .pptx
+  - `ValidateImagePath`: null/empty, file not found, unsupported extensions (.txt/.pdf/.docx/.pptx), all 9 supported formats
+  - `ValidateColorFormat`: invalid formats (words, short hex, bad chars), valid 6-digit hex, '#' prefix is stripped (accepted), null/empty silently accepted
+  - `BuildShapeNotFoundMessage`: includes shape name + available list, empty list → "no shapes"
+  - `BuildTableNotFoundMessage`: by name (includes count), by index (includes valid range), neither (generic)
+  - `ValidateRowIndex`/`ValidateColumnIndex`: out-of-range with table name in message, valid range accepted
+- **Integration tests:** 7 tests verifying validation flows through service methods (InsertTable/UpdateTable/DeleteSlide slide numbers, InsertImage EMU/extension, UpdateSlideData shape/range messages)
+- **Key findings:**
+  - `ValidateColorFormat` accepts '#' prefix by stripping it — differs from initial spec which expected rejection
+  - `ValidateColorFormat` returns silently on null/empty (optional color parameter pattern)
+  - Parallel agent work required polling for file existence before writing tests
+  - Cheritto's commit included the test file (committed whole working tree) — no separate test commit needed

--- a/src/PptxTools/Services/PresentationService.TableStructure.cs
+++ b/src/PptxTools/Services/PresentationService.TableStructure.cs
@@ -66,7 +66,7 @@ public partial class PresentationService
 
         if (rowIndex < 0 || rowIndex >= tableRows.Count)
             throw new ArgumentOutOfRangeException(nameof(rowIndex),
-                $"Row index {rowIndex} is out of range. Table has {tableRows.Count} row(s).");
+                $"Row index {rowIndex} is out of range. Table has {tableRows.Count} row(s), valid range: 0-{tableRows.Count - 1}.");
 
         tableRows[rowIndex].Remove();
         slidePart.Slide.Save();
@@ -160,7 +160,7 @@ public partial class PresentationService
 
         if (columnIndex < 0 || columnIndex >= currentColumnCount)
             throw new ArgumentOutOfRangeException(nameof(columnIndex),
-                $"Column index {columnIndex} is out of range. Table has {currentColumnCount} column(s).");
+                $"Column index {columnIndex} is out of range. Table has {currentColumnCount} column(s), valid range: 0-{currentColumnCount - 1}.");
 
         // 1. Remove GridColumn
         gridColumns[columnIndex].Remove();
@@ -264,6 +264,7 @@ public partial class PresentationService
         int? tableIndex)
     {
         var slideIds = GetSlideIds(doc);
+        ValidationHelpers.ValidateSlideNumber(slideNumber, slideIds.Count);
         var slidePart = GetSlidePart(doc, slideIds, slideNumber - 1);
         var shapeTree = slidePart.Slide.CommonSlideData!.ShapeTree!;
 
@@ -290,14 +291,14 @@ public partial class PresentationService
                     tables.Select((gf, i) =>
                         $"{i}:{gf.NonVisualGraphicFrameProperties?.NonVisualDrawingProperties?.Name?.Value ?? "(unnamed)"}"));
                 throw new InvalidOperationException(
-                    $"No table named '{tableName}' found on slide {slideNumber}. Available tables: {available}");
+                    $"No table named '{tableName}' found on slide {slideNumber}. Found {tables.Count} table(s). Available tables: {available}");
             }
         }
         else if (tableIndex.HasValue)
         {
             if (tableIndex.Value < 0 || tableIndex.Value >= tables.Count)
                 throw new ArgumentOutOfRangeException(nameof(tableIndex),
-                    $"Table index {tableIndex.Value} is out of range. Slide {slideNumber} has {tables.Count} table(s).");
+                    $"Table index {tableIndex.Value} is out of range. Slide {slideNumber} has {tables.Count} table(s), valid range: 0-{tables.Count - 1}.");
             targetFrame = tables[tableIndex.Value];
         }
         else

--- a/src/PptxTools/Services/PresentationService.cs
+++ b/src/PptxTools/Services/PresentationService.cs
@@ -358,6 +358,12 @@ public partial class PresentationService
 
     public void InsertImage(string filePath, int slideIndex, string imagePath, long x, long y, long width, long height)
     {
+        ValidationHelpers.ValidateImagePath(imagePath);
+        ValidationHelpers.ValidateEmuValue(x, nameof(x));
+        ValidationHelpers.ValidateEmuValue(y, nameof(y));
+        ValidationHelpers.ValidateEmuValue(width, nameof(width));
+        ValidationHelpers.ValidateEmuValue(height, nameof(height));
+
         using var doc = PresentationDocument.Open(filePath, true);
         var slidePart = GetSlidePart(doc, slideIndex);
 
@@ -404,8 +410,14 @@ public partial class PresentationService
         long width = 7315200,
         long height = 1371600)
     {
+        ValidationHelpers.ValidateEmuValue(x, nameof(x));
+        ValidationHelpers.ValidateEmuValue(y, nameof(y));
+        ValidationHelpers.ValidateEmuValue(width, nameof(width));
+        ValidationHelpers.ValidateEmuValue(height, nameof(height));
+
         using var doc = PresentationDocument.Open(filePath, true);
         var slideIds = GetSlideIds(doc);
+        ValidationHelpers.ValidateSlideNumber(slideNumber, slideIds.Count);
         var slidePart = GetSlidePart(doc, slideIds, slideNumber - 1);
         var shapeTree = slidePart.Slide.CommonSlideData!.ShapeTree!;
 
@@ -488,6 +500,7 @@ public partial class PresentationService
     {
         using var doc = PresentationDocument.Open(filePath, true);
         var slideIds = GetSlideIds(doc);
+        ValidationHelpers.ValidateSlideNumber(slideNumber, slideIds.Count);
         var slidePart = GetSlidePart(doc, slideIds, slideNumber - 1);
         var shapeTree = slidePart.Slide.CommonSlideData!.ShapeTree!;
 
@@ -627,7 +640,7 @@ public partial class PresentationService
             CellsUpdated: cellsUpdated,
             CellsSkipped: cellsSkipped,
             Message: $"Updated {cellsUpdated} cell(s) in table '{resolvedName}' on slide {slideNumber}."
-                + (cellsSkipped > 0 ? $" {cellsSkipped} update(s) skipped (out of range)." : ""));
+                + (cellsSkipped > 0 ? $" {cellsSkipped} update(s) skipped (out of range). Table has {tableRows.Count} row(s) and {table.TableGrid!.Elements<A.GridColumn>().Count()} column(s)." : ""));
     }
 
     private static A.TableRow BuildTableRow(string[] cellValues, long rowHeight)
@@ -683,10 +696,7 @@ public partial class PresentationService
 
     private static SlidePart GetSlidePart(PresentationDocument doc, IReadOnlyList<SlideId> slideIds, int slideIndex)
     {
-        if (slideIds.Count == 0)
-            throw new InvalidOperationException("Presentation has no slides.");
-        if (slideIndex < 0 || slideIndex >= slideIds.Count)
-            throw new ArgumentOutOfRangeException(nameof(slideIndex), $"Slide index {slideIndex} is out of range. Presentation has {slideIds.Count} slide(s).");
+        ValidationHelpers.ValidateSlideIndex(slideIndex, slideIds.Count);
         return (SlidePart)doc.PresentationPart!.GetPartById(slideIds[slideIndex].RelationshipId!.Value!);
     }
 
@@ -717,7 +727,8 @@ public partial class PresentationService
             return CreateSlideDataUpdateFailure(slideNumber, shapeName, placeholderIndex, newText, "Presentation has no slides.");
 
         if (slideNumber > slideIds.Count)
-            return CreateSlideDataUpdateFailure(slideNumber, shapeName, placeholderIndex, newText, $"slideNumber {slideNumber} is out of range. Presentation has {slideIds.Count} slide(s).");
+            return CreateSlideDataUpdateFailure(slideNumber, shapeName, placeholderIndex, newText,
+                $"Slide {slideNumber} does not exist — out of range. Valid range: 1-{slideIds.Count}. Presentation has {slideIds.Count} slide(s).");
 
         var slidePart = GetSlidePart(doc, slideIds, slideNumber - 1);
         if (slidePart.Slide is null)
@@ -1660,8 +1671,7 @@ public partial class PresentationService
 
         if (count == 1)
             throw new InvalidOperationException("Cannot delete the only slide in a presentation.");
-        if (slideNumber < 1 || slideNumber > count)
-            throw new ArgumentOutOfRangeException(nameof(slideNumber), $"slideNumber {slideNumber} is out of range. Presentation has {count} slide(s).");
+        ValidationHelpers.ValidateSlideNumber(slideNumber, count);
 
         var slideId = slideIds[slideNumber - 1];
         var slidePart = (SlidePart)presentationPart.GetPartById(slideId.RelationshipId!.Value!);
@@ -1714,14 +1724,16 @@ public partial class PresentationService
         var slideIds = GetSlideIds(doc);
 
         if (slideNumber <= 0)
-            return new ImageReplaceResult(false, slideNumber, null, null, null, null, altText, "slideNumber must be 1 or greater.");
+            return new ImageReplaceResult(false, slideNumber, null, null, null, null, altText,
+                "slideNumber must be 1 or greater.");
 
         if (slideIds.Count == 0)
-            return new ImageReplaceResult(false, slideNumber, null, null, null, null, altText, "Presentation has no slides.");
+            return new ImageReplaceResult(false, slideNumber, null, null, null, null, altText,
+                "Presentation has no slides.");
 
         if (slideNumber > slideIds.Count)
             return new ImageReplaceResult(false, slideNumber, null, null, null, null, altText,
-                $"slideNumber {slideNumber} is out of range. Presentation has {slideIds.Count} slide(s).");
+                $"Slide {slideNumber} does not exist — out of range. Valid range: 1-{slideIds.Count}.");
 
         if (string.IsNullOrWhiteSpace(shapeName) && shapeIndex is null)
             return new ImageReplaceResult(false, slideNumber, null, null, null, null, altText, "Provide either shapeName or shapeIndex.");

--- a/src/PptxTools/Services/ValidationHelpers.cs
+++ b/src/PptxTools/Services/ValidationHelpers.cs
@@ -1,0 +1,132 @@
+namespace PptxTools.Services;
+
+/// <summary>
+/// Centralized validation helpers that produce actionable error messages for MCP consumers.
+/// All methods throw standard exceptions caught by the ExecuteToolStructured pattern in the tool layer.
+/// </summary>
+public static class ValidationHelpers
+{
+    /// <summary>Validate a 1-based slide number is in range.</summary>
+    public static void ValidateSlideNumber(int slideNumber, int totalSlides, string context = "")
+    {
+        if (totalSlides == 0)
+            throw new InvalidOperationException("Presentation has no slides.");
+
+        if (slideNumber < 1 || slideNumber > totalSlides)
+        {
+            var msg = $"Slide {slideNumber} does not exist — out of range. Valid range: 1-{totalSlides}.";
+            if (!string.IsNullOrWhiteSpace(context))
+                msg += $" {context}";
+            throw new ArgumentOutOfRangeException(nameof(slideNumber), msg);
+        }
+    }
+
+    /// <summary>Validate a 0-based slide index is in range.</summary>
+    public static void ValidateSlideIndex(int slideIndex, int totalSlides, string context = "")
+    {
+        if (totalSlides == 0)
+            throw new InvalidOperationException("Presentation has no slides.");
+
+        if (slideIndex < 0 || slideIndex >= totalSlides)
+        {
+            var msg = $"Slide index {slideIndex} is out of range. Presentation has {totalSlides} slide(s), valid range: 0-{totalSlides - 1}.";
+            if (!string.IsNullOrWhiteSpace(context))
+                msg += $" {context}";
+            throw new ArgumentOutOfRangeException(nameof(slideIndex), msg);
+        }
+    }
+
+    /// <summary>Validate EMU coordinates (position/size) are non-negative.</summary>
+    public static void ValidateEmuValue(long value, string paramName)
+    {
+        if (value < 0)
+            throw new ArgumentOutOfRangeException(paramName,
+                $"EMU value for '{paramName}' must be non-negative. Got: {value}. (1 inch = 914400 EMU)");
+    }
+
+    /// <summary>Validate a .pptx file path exists and has the correct extension.</summary>
+    public static void ValidateFilePath(string filePath)
+    {
+        if (string.IsNullOrWhiteSpace(filePath))
+            throw new ArgumentException("File path must not be empty.", nameof(filePath));
+
+        if (!File.Exists(filePath))
+            throw new FileNotFoundException($"File not found: '{filePath}'. Verify the path is correct and the file exists.", filePath);
+
+        var ext = Path.GetExtension(filePath);
+        if (!string.Equals(ext, ".pptx", StringComparison.OrdinalIgnoreCase))
+            throw new ArgumentException(
+                $"Expected a .pptx file but got '{ext}'. Provide a PowerPoint (.pptx) file.", nameof(filePath));
+    }
+
+    private static readonly HashSet<string> SupportedImageExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".png", ".jpg", ".jpeg", ".gif", ".bmp", ".tiff", ".svg", ".emf", ".wmf"
+    };
+
+    /// <summary>Validate an image file path exists and has a supported format.</summary>
+    public static void ValidateImagePath(string imagePath)
+    {
+        if (string.IsNullOrWhiteSpace(imagePath))
+            throw new ArgumentException("Image path must not be empty.", nameof(imagePath));
+
+        if (!File.Exists(imagePath))
+            throw new FileNotFoundException($"Image file not found: '{imagePath}'. Verify the path is correct.", imagePath);
+
+        var ext = Path.GetExtension(imagePath);
+        if (!SupportedImageExtensions.Contains(ext))
+            throw new ArgumentException(
+                $"Unsupported image format '{ext}'. Supported: .png, .jpg, .jpeg, .gif, .bmp, .tiff, .svg, .emf, .wmf",
+                nameof(imagePath));
+    }
+
+    /// <summary>Validate a 6-digit hex color string (with or without '#' prefix).</summary>
+    public static void ValidateColorFormat(string color, string paramName)
+    {
+        if (string.IsNullOrWhiteSpace(color))
+            return;
+
+        var hex = color.StartsWith('#') ? color[1..] : color;
+        if (!System.Text.RegularExpressions.Regex.IsMatch(hex, @"^[0-9A-Fa-f]{6}$"))
+            throw new ArgumentException(
+                $"Invalid color format for '{paramName}': '{color}'. Expected 6-digit hex (e.g., 'FF0000' for red, '0000FF' for blue).",
+                paramName);
+    }
+
+    /// <summary>Build an actionable "shape not found" message listing available shapes.</summary>
+    public static string BuildShapeNotFoundMessage(int slideNumber, string requestedShape, IEnumerable<string> availableShapes)
+    {
+        var shapeList = string.Join(", ", availableShapes);
+        return string.IsNullOrEmpty(shapeList)
+            ? $"Shape '{requestedShape}' not found on slide {slideNumber}. The slide has no shapes."
+            : $"Shape '{requestedShape}' not found on slide {slideNumber}. Available shapes: {shapeList}";
+    }
+
+    /// <summary>Build an actionable "table not found" message with count context.</summary>
+    public static string BuildTableNotFoundMessage(int slideNumber, string? tableName, int? tableIndex, int tableCount)
+    {
+        if (tableName is not null)
+            return $"Table '{tableName}' not found on slide {slideNumber}. Found {tableCount} table(s).";
+
+        if (tableIndex.HasValue)
+            return $"Table index {tableIndex.Value} is out of range on slide {slideNumber}. Found {tableCount} table(s), valid range: 0-{tableCount - 1}.";
+
+        return $"No table found on slide {slideNumber}. Found {tableCount} table(s).";
+    }
+
+    /// <summary>Validate a row index is within a table's row count.</summary>
+    public static void ValidateRowIndex(int rowIndex, int rowCount, string tableName)
+    {
+        if (rowIndex < 0 || rowIndex >= rowCount)
+            throw new ArgumentOutOfRangeException(nameof(rowIndex),
+                $"Row index {rowIndex} is out of range. Table '{tableName}' has {rowCount} row(s), valid range: 0-{rowCount - 1}.");
+    }
+
+    /// <summary>Validate a column index is within a table's column count.</summary>
+    public static void ValidateColumnIndex(int columnIndex, int columnCount, string tableName)
+    {
+        if (columnIndex < 0 || columnIndex >= columnCount)
+            throw new ArgumentOutOfRangeException(nameof(columnIndex),
+                $"Column index {columnIndex} is out of range. Table '{tableName}' has {columnCount} column(s), valid range: 0-{columnCount - 1}.");
+    }
+}

--- a/tests/PptxTools.Tests/Services/ValidationHelperTests.cs
+++ b/tests/PptxTools.Tests/Services/ValidationHelperTests.cs
@@ -1,0 +1,508 @@
+namespace PptxTools.Tests.Services;
+
+/// <summary>
+/// Tests for <see cref="ValidationHelpers"/> — centralized validation that produces
+/// actionable error messages for MCP consumers. Covers every public method: slide
+/// number/index validation, EMU values, file/image paths, color formats, and the
+/// human-readable "not found" message builders.
+/// </summary>
+public class ValidationHelperTests : PptxTestBase
+{
+    // ────────────────────────────────────────────────────────────────────────
+    // ValidateSlideNumber
+    // ────────────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(0, 5)]
+    [InlineData(-1, 5)]
+    [InlineData(6, 5)]
+    [InlineData(10, 3)]
+    public void ValidateSlideNumber_OutOfRange_ThrowsWithRangeInfo(int slideNumber, int totalSlides)
+    {
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(
+            () => ValidationHelpers.ValidateSlideNumber(slideNumber, totalSlides));
+        Assert.Contains($"1-{totalSlides}", ex.Message);
+    }
+
+    [Theory]
+    [InlineData(1, 1)]
+    [InlineData(1, 5)]
+    [InlineData(3, 5)]
+    [InlineData(5, 5)]
+    public void ValidateSlideNumber_ValidRange_DoesNotThrow(int slideNumber, int totalSlides)
+    {
+        var exception = Record.Exception(
+            () => ValidationHelpers.ValidateSlideNumber(slideNumber, totalSlides));
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void ValidateSlideNumber_ZeroTotalSlides_ThrowsInvalidOperation()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => ValidationHelpers.ValidateSlideNumber(1, 0));
+        Assert.Contains("no slides", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ValidateSlideNumber_WithContext_IncludesContextInMessage()
+    {
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(
+            () => ValidationHelpers.ValidateSlideNumber(10, 3, "while updating table"));
+        Assert.Contains("while updating table", ex.Message);
+        Assert.Contains("1-3", ex.Message);
+    }
+
+    [Theory]
+    [InlineData(1, 5)]
+    [InlineData(5, 5)]
+    public void ValidateSlideNumber_EmptyContext_OmitsTrailingContext(int slideNumber, int totalSlides)
+    {
+        // Empty context should not append extra whitespace or text
+        var exception = Record.Exception(
+            () => ValidationHelpers.ValidateSlideNumber(slideNumber, totalSlides, ""));
+        Assert.Null(exception);
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // ValidateSlideIndex
+    // ────────────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(-1, 5)]
+    [InlineData(5, 5)]
+    [InlineData(10, 3)]
+    public void ValidateSlideIndex_OutOfRange_ThrowsWithRangeInfo(int slideIndex, int totalSlides)
+    {
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(
+            () => ValidationHelpers.ValidateSlideIndex(slideIndex, totalSlides));
+        Assert.Contains($"0-{totalSlides - 1}", ex.Message);
+    }
+
+    [Theory]
+    [InlineData(0, 1)]
+    [InlineData(0, 5)]
+    [InlineData(2, 5)]
+    [InlineData(4, 5)]
+    public void ValidateSlideIndex_ValidRange_DoesNotThrow(int slideIndex, int totalSlides)
+    {
+        var exception = Record.Exception(
+            () => ValidationHelpers.ValidateSlideIndex(slideIndex, totalSlides));
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void ValidateSlideIndex_ZeroTotalSlides_ThrowsInvalidOperation()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => ValidationHelpers.ValidateSlideIndex(0, 0));
+        Assert.Contains("no slides", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ValidateSlideIndex_WithContext_IncludesContextInMessage()
+    {
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(
+            () => ValidationHelpers.ValidateSlideIndex(5, 3, "during XML extraction"));
+        Assert.Contains("during XML extraction", ex.Message);
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // ValidateEmuValue
+    // ────────────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(-914400)]
+    [InlineData(long.MinValue)]
+    public void ValidateEmuValue_Negative_ThrowsWithEmuExplanation(long value)
+    {
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(
+            () => ValidationHelpers.ValidateEmuValue(value, "width"));
+        Assert.Contains("width", ex.Message);
+        Assert.Contains("914400", ex.Message); // EMU conversion hint
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(914400)]
+    [InlineData(long.MaxValue)]
+    public void ValidateEmuValue_ZeroOrPositive_DoesNotThrow(long value)
+    {
+        var exception = Record.Exception(
+            () => ValidationHelpers.ValidateEmuValue(value, "x"));
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void ValidateEmuValue_IncludesParamNameInMessage()
+    {
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(
+            () => ValidationHelpers.ValidateEmuValue(-100, "tableHeight"));
+        Assert.Contains("tableHeight", ex.Message);
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // ValidateFilePath
+    // ────────────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ValidateFilePath_NullOrEmpty_ThrowsArgumentException(string? filePath)
+    {
+        Assert.Throws<ArgumentException>(
+            () => ValidationHelpers.ValidateFilePath(filePath!));
+    }
+
+    [Fact]
+    public void ValidateFilePath_FileDoesNotExist_ThrowsFileNotFound()
+    {
+        var ex = Assert.Throws<FileNotFoundException>(
+            () => ValidationHelpers.ValidateFilePath(@"C:\nonexistent\fake.pptx"));
+        Assert.Contains("not found", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ValidateFilePath_NonPptxExtension_ThrowsArgumentException()
+    {
+        // Create a real file with wrong extension
+        var path = Path.Join(Path.GetTempPath(), Path.GetRandomFileName() + ".docx");
+        File.WriteAllText(path, "dummy");
+        TrackTempFile(path);
+
+        var ex = Assert.Throws<ArgumentException>(
+            () => ValidationHelpers.ValidateFilePath(path));
+        Assert.Contains(".pptx", ex.Message);
+    }
+
+    [Fact]
+    public void ValidateFilePath_ValidPptx_DoesNotThrow()
+    {
+        var path = CreateMinimalPptx();
+
+        var exception = Record.Exception(
+            () => ValidationHelpers.ValidateFilePath(path));
+        Assert.Null(exception);
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // ValidateImagePath
+    // ────────────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ValidateImagePath_NullOrEmpty_ThrowsArgumentException(string? imagePath)
+    {
+        Assert.Throws<ArgumentException>(
+            () => ValidationHelpers.ValidateImagePath(imagePath!));
+    }
+
+    [Fact]
+    public void ValidateImagePath_FileDoesNotExist_ThrowsFileNotFound()
+    {
+        var ex = Assert.Throws<FileNotFoundException>(
+            () => ValidationHelpers.ValidateImagePath(@"C:\nonexistent\fake.png"));
+        Assert.Contains("not found", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData(".txt")]
+    [InlineData(".pdf")]
+    [InlineData(".docx")]
+    [InlineData(".pptx")]
+    public void ValidateImagePath_UnsupportedExtension_ThrowsWithSupportedFormats(string ext)
+    {
+        var path = Path.Join(Path.GetTempPath(), Path.GetRandomFileName() + ext);
+        File.WriteAllText(path, "dummy");
+        TrackTempFile(path);
+
+        var ex = Assert.Throws<ArgumentException>(
+            () => ValidationHelpers.ValidateImagePath(path));
+        Assert.Contains(".png", ex.Message);
+        Assert.Contains(".jpg", ex.Message);
+    }
+
+    [Theory]
+    [InlineData(".png")]
+    [InlineData(".jpg")]
+    [InlineData(".jpeg")]
+    [InlineData(".gif")]
+    [InlineData(".bmp")]
+    [InlineData(".tiff")]
+    [InlineData(".svg")]
+    [InlineData(".emf")]
+    [InlineData(".wmf")]
+    public void ValidateImagePath_SupportedExtension_DoesNotThrow(string ext)
+    {
+        var path = Path.Join(Path.GetTempPath(), Path.GetRandomFileName() + ext);
+        File.WriteAllText(path, "dummy image content");
+        TrackTempFile(path);
+
+        var exception = Record.Exception(
+            () => ValidationHelpers.ValidateImagePath(path));
+        Assert.Null(exception);
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // ValidateColorFormat
+    // ────────────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("red")]
+    [InlineData("GG0000")]
+    [InlineData("FF00")]
+    [InlineData("ZZZZZZ")]
+    [InlineData("12345")]
+    [InlineData("1234567")]
+    public void ValidateColorFormat_InvalidFormat_ThrowsWithFormatHelp(string color)
+    {
+        var ex = Assert.Throws<ArgumentException>(
+            () => ValidationHelpers.ValidateColorFormat(color, "fontColor"));
+        Assert.Contains("fontColor", ex.Message);
+        Assert.Contains("hex", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("FF0000")]
+    [InlineData("00FF00")]
+    [InlineData("0000FF")]
+    [InlineData("000000")]
+    [InlineData("FFFFFF")]
+    [InlineData("abcdef")]
+    public void ValidateColorFormat_ValidHex_DoesNotThrow(string color)
+    {
+        var exception = Record.Exception(
+            () => ValidationHelpers.ValidateColorFormat(color, "fill"));
+        Assert.Null(exception);
+    }
+
+    [Theory]
+    [InlineData("#FF0000")]
+    [InlineData("#00ff00")]
+    public void ValidateColorFormat_HashPrefixed_IsAccepted(string color)
+    {
+        // Implementation strips the '#' prefix — these are valid
+        var exception = Record.Exception(
+            () => ValidationHelpers.ValidateColorFormat(color, "fill"));
+        Assert.Null(exception);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ValidateColorFormat_NullOrEmpty_DoesNotThrow(string? color)
+    {
+        // Null/empty is silently accepted (optional color parameter)
+        var exception = Record.Exception(
+            () => ValidationHelpers.ValidateColorFormat(color!, "fill"));
+        Assert.Null(exception);
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // BuildShapeNotFoundMessage
+    // ────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void BuildShapeNotFoundMessage_ReturnsMessageWithShapeAndAvailable()
+    {
+        var msg = ValidationHelpers.BuildShapeNotFoundMessage(
+            3, "Revenue", ["Title", "Subtitle", "Footer"]);
+
+        Assert.Contains("Revenue", msg);
+        Assert.Contains("slide 3", msg);
+        Assert.Contains("Title", msg);
+        Assert.Contains("Subtitle", msg);
+        Assert.Contains("Footer", msg);
+    }
+
+    [Fact]
+    public void BuildShapeNotFoundMessage_EmptyAvailableShapes_StillWorks()
+    {
+        var msg = ValidationHelpers.BuildShapeNotFoundMessage(
+            1, "MissingShape", []);
+
+        Assert.Contains("MissingShape", msg);
+        Assert.Contains("slide 1", msg);
+        Assert.Contains("no shapes", msg, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // BuildTableNotFoundMessage
+    // ────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void BuildTableNotFoundMessage_ByName_IncludesNameAndCount()
+    {
+        var msg = ValidationHelpers.BuildTableNotFoundMessage(2, "SalesData", null, 3);
+
+        Assert.Contains("SalesData", msg);
+        Assert.Contains("slide 2", msg);
+        Assert.Contains("3", msg);
+    }
+
+    [Fact]
+    public void BuildTableNotFoundMessage_ByIndex_IncludesIndexAndCount()
+    {
+        var msg = ValidationHelpers.BuildTableNotFoundMessage(1, null, 5, 3);
+
+        Assert.Contains("5", msg);
+        Assert.Contains("slide 1", msg);
+        Assert.Contains("3", msg);
+        Assert.Contains("0-2", msg); // valid range
+    }
+
+    [Fact]
+    public void BuildTableNotFoundMessage_NeitherNameNorIndex_ReturnsGenericMessage()
+    {
+        var msg = ValidationHelpers.BuildTableNotFoundMessage(4, null, null, 0);
+
+        Assert.Contains("slide 4", msg);
+        Assert.Contains("0", msg);
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // ValidateRowIndex / ValidateColumnIndex
+    // ────────────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(-1, 5)]
+    [InlineData(5, 5)]
+    [InlineData(10, 3)]
+    public void ValidateRowIndex_OutOfRange_ThrowsWithRangeInfo(int rowIndex, int rowCount)
+    {
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(
+            () => ValidationHelpers.ValidateRowIndex(rowIndex, rowCount, "Revenue"));
+        Assert.Contains("Revenue", ex.Message);
+        Assert.Contains($"0-{rowCount - 1}", ex.Message);
+    }
+
+    [Theory]
+    [InlineData(0, 1)]
+    [InlineData(0, 5)]
+    [InlineData(4, 5)]
+    public void ValidateRowIndex_ValidRange_DoesNotThrow(int rowIndex, int rowCount)
+    {
+        var exception = Record.Exception(
+            () => ValidationHelpers.ValidateRowIndex(rowIndex, rowCount, "Data"));
+        Assert.Null(exception);
+    }
+
+    [Theory]
+    [InlineData(-1, 4)]
+    [InlineData(4, 4)]
+    [InlineData(10, 2)]
+    public void ValidateColumnIndex_OutOfRange_ThrowsWithRangeInfo(int colIndex, int colCount)
+    {
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(
+            () => ValidationHelpers.ValidateColumnIndex(colIndex, colCount, "Sales"));
+        Assert.Contains("Sales", ex.Message);
+        Assert.Contains($"0-{colCount - 1}", ex.Message);
+    }
+
+    [Theory]
+    [InlineData(0, 1)]
+    [InlineData(0, 4)]
+    [InlineData(3, 4)]
+    public void ValidateColumnIndex_ValidRange_DoesNotThrow(int colIndex, int colCount)
+    {
+        var exception = Record.Exception(
+            () => ValidationHelpers.ValidateColumnIndex(colIndex, colCount, "Data"));
+        Assert.Null(exception);
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // Integration: ValidationHelpers flow through service methods
+    // ────────────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(99)]
+    public void InsertTable_InvalidSlideNumber_ErrorIncludesRange(int slideNumber)
+    {
+        var path = CreateMinimalPptx();
+
+        var ex = Assert.ThrowsAny<Exception>(
+            () => Service.InsertTable(path, slideNumber, ["A"], [["1"]]));
+        // Should include range info or "no slides" context
+        Assert.True(
+            ex.Message.Contains("1-1") || ex.Message.Contains("no slides", StringComparison.OrdinalIgnoreCase),
+            $"Expected range info in message but got: {ex.Message}");
+    }
+
+    [Fact]
+    public void UpdateTable_InvalidSlideNumber_ErrorIncludesRange()
+    {
+        var path = CreateMinimalPptx();
+        var updates = new[] { new TableCellUpdate(0, 0, "val") };
+
+        var ex = Assert.ThrowsAny<Exception>(
+            () => Service.UpdateTable(path, 99, updates));
+        Assert.Contains("1-1", ex.Message);
+    }
+
+    [Fact]
+    public void InsertImage_NegativeEmu_ErrorIncludesParamName()
+    {
+        var path = CreateMinimalPptx();
+        var imgPath = Path.Join(Path.GetTempPath(), Path.GetRandomFileName() + ".png");
+        File.WriteAllBytes(imgPath, [0x89, 0x50, 0x4E, 0x47]); // minimal PNG header
+        TrackTempFile(imgPath);
+
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(
+            () => Service.InsertImage(path, 0, imgPath, -100, 0, 100, 100));
+        Assert.Contains("x", ex.Message);
+    }
+
+    [Fact]
+    public void InsertImage_InvalidImageExtension_ErrorListsSupportedFormats()
+    {
+        var path = CreateMinimalPptx();
+        var badImg = Path.Join(Path.GetTempPath(), Path.GetRandomFileName() + ".txt");
+        File.WriteAllText(badImg, "not an image");
+        TrackTempFile(badImg);
+
+        var ex = Assert.Throws<ArgumentException>(
+            () => Service.InsertImage(path, 0, badImg, 0, 0, 100, 100));
+        Assert.Contains(".png", ex.Message);
+    }
+
+    [Fact]
+    public void UpdateSlideData_InvalidShapeName_ErrorIncludesAvailableShapes()
+    {
+        var path = CreatePptxWithSlides(
+            new TestSlideDefinition { TitleText = "Dashboard" });
+
+        var result = Service.UpdateSlideData(path, 1, "NonexistentShape", null, "new text");
+        Assert.False(result.Success);
+        Assert.Contains("Available shapes", result.Message!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void UpdateSlideData_SlideNumberTooHigh_ErrorIncludesSlideCount()
+    {
+        var path = CreateMinimalPptx();
+
+        var result = Service.UpdateSlideData(path, 99, "Title", null, "new text");
+        Assert.False(result.Success);
+        Assert.Contains("1 slide", result.Message!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void DeleteSlide_InvalidSlideNumber_ThrowsWithRange()
+    {
+        var path = CreatePptxWithSlides(
+            new TestSlideDefinition { TitleText = "A" },
+            new TestSlideDefinition { TitleText = "B" });
+
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(
+            () => Service.DeleteSlide(path, 5));
+        Assert.Contains("1-2", ex.Message);
+    }
+}


### PR DESCRIPTION
## Summary

Adds centralized `ValidationHelpers.cs` and applies validation to the most impactful service methods. When something goes wrong, users now get actionable information to fix it.

### What changed

**New file:** `src/PptxTools/Services/ValidationHelpers.cs`
- `ValidateSlideNumber` / `ValidateSlideIndex` — range validation with valid range in message
- `ValidateEmuValue` — catches negative EMU values early with unit hint
- `ValidateImagePath` — checks existence + supported format list
- `ValidateFilePath` — checks existence + .pptx extension
- `ValidateColorFormat` — hex color validation
- `BuildShapeNotFoundMessage` / `BuildTableNotFoundMessage` — actionable not-found messages
- `ValidateRowIndex` / `ValidateColumnIndex` — table dimension validation

**Enhanced service methods:**
- `GetSlidePart`: uses `ValidateSlideIndex` — all 0-based callers get better messages
- `InsertImage`: validates image format + EMU values before opening file
- `InsertTable`: validates slide number + EMU values
- `UpdateTable`: validates slide number, includes table dimensions when cells skipped
- `DeleteSlide`: uses `ValidateSlideNumber`
- `UpdateSlideData`: enhanced range message with valid range (1-N)
- `ReplaceImage`: enhanced range message with valid range
- `FindTableOnSlide`: validates slide number, includes table count in not-found messages
- `DeleteTableRow` / `DeleteTableColumn`: includes valid range in messages

### Constraints respected
- No method signatures or return types changed
- No tool layer files modified
- All error messages preserve backward-compatible keywords (`out of range`, `not found`, etc.)
- 1227 tests pass, 0 failures

Closes #140